### PR TITLE
feat(db): add DJ service database migrations 016-021

### DIFF
--- a/shared/db/src/migrations/016_create_dj_profiles.sql
+++ b/shared/db/src/migrations/016_create_dj_profiles.sql
@@ -1,0 +1,17 @@
+CREATE TABLE dj_profiles (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    station_id     UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    name           VARCHAR(255) NOT NULL,
+    persona_prompt TEXT NOT NULL,
+    tone           VARCHAR(100) NOT NULL,
+    energy_level   VARCHAR(100) NOT NULL,
+    catchphrases   TEXT[] NOT NULL DEFAULT '{}',
+    voice_config   JSONB NOT NULL DEFAULT '{}',
+    is_default     BOOLEAN NOT NULL DEFAULT FALSE,
+    is_active      BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dj_profiles_station ON dj_profiles(station_id);
+CREATE UNIQUE INDEX idx_dj_profiles_station_default ON dj_profiles(station_id) WHERE is_default = TRUE;

--- a/shared/db/src/migrations/017_create_dj_daypart_assignments.sql
+++ b/shared/db/src/migrations/017_create_dj_daypart_assignments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE dj_daypart_assignments (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    station_id     UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    dj_profile_id  UUID NOT NULL REFERENCES dj_profiles(id) ON DELETE CASCADE,
+    start_hour     SMALLINT NOT NULL,
+    end_hour       SMALLINT NOT NULL,
+    days_of_week   VARCHAR(3)[] NOT NULL DEFAULT ARRAY['MON','TUE','WED','THU','FRI','SAT','SUN'],
+    priority       INTEGER NOT NULL DEFAULT 1,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dj_dayparts_station ON dj_daypart_assignments(station_id);
+CREATE INDEX idx_dj_dayparts_profile ON dj_daypart_assignments(dj_profile_id);

--- a/shared/db/src/migrations/018_create_dj_script_templates.sql
+++ b/shared/db/src/migrations/018_create_dj_script_templates.sql
@@ -1,0 +1,12 @@
+CREATE TABLE dj_script_templates (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    station_id     UUID REFERENCES stations(id) ON DELETE CASCADE,
+    segment_type   VARCHAR(50) NOT NULL
+                   CHECK (segment_type IN ('segue','song_intro','song_outro','show_open','show_close','time_check','station_id')),
+    prompt_template TEXT NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(station_id, segment_type)
+);
+
+CREATE INDEX idx_dj_templates_station ON dj_script_templates(station_id);

--- a/shared/db/src/migrations/019_create_dj_scripts.sql
+++ b/shared/db/src/migrations/019_create_dj_scripts.sql
@@ -1,0 +1,15 @@
+CREATE TABLE dj_scripts (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    station_id    UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    playlist_id   UUID NOT NULL REFERENCES playlists(id) ON DELETE CASCADE,
+    status        VARCHAR(30) NOT NULL DEFAULT 'queued'
+                  CHECK (status IN ('queued','generating_scripts','generating_audio','completed','failed')),
+    error_message TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at  TIMESTAMPTZ
+);
+
+CREATE INDEX idx_dj_scripts_station ON dj_scripts(station_id);
+CREATE INDEX idx_dj_scripts_playlist ON dj_scripts(playlist_id);
+CREATE INDEX idx_dj_scripts_status ON dj_scripts(status);

--- a/shared/db/src/migrations/020_create_dj_segments.sql
+++ b/shared/db/src/migrations/020_create_dj_segments.sql
@@ -1,0 +1,17 @@
+CREATE TABLE dj_segments (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dj_script_id      UUID NOT NULL REFERENCES dj_scripts(id) ON DELETE CASCADE,
+    dj_profile_id     UUID NOT NULL REFERENCES dj_profiles(id) ON DELETE CASCADE,
+    segment_type      VARCHAR(50) NOT NULL
+                      CHECK (segment_type IN ('segue','song_intro','song_outro','show_open','show_close','time_check','station_id')),
+    script_text       TEXT,
+    audio_file_path   VARCHAR(255),
+    audio_duration_ms INTEGER,
+    before_song_id    UUID, -- Can refer to playlist_entries(id)
+    after_song_id     UUID,  -- Can refer to playlist_entries(id)
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dj_segments_script ON dj_segments(dj_script_id);
+CREATE INDEX idx_dj_segments_profile ON dj_segments(dj_profile_id);

--- a/shared/db/src/migrations/021_create_dj_show_manifest.sql
+++ b/shared/db/src/migrations/021_create_dj_show_manifest.sql
@@ -1,0 +1,9 @@
+CREATE TABLE dj_show_manifests (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    dj_script_id  UUID NOT NULL UNIQUE REFERENCES dj_scripts(id) ON DELETE CASCADE,
+    manifest      JSONB NOT NULL DEFAULT '[]',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dj_manifests_script ON dj_show_manifests(dj_script_id);


### PR DESCRIPTION
Implements Issue #6. Adds migrations for dj_profiles, daypart_assignments, script_templates, scripts, segments, and manifests.