### PR TITLE
feat(station): configurable DJ script review toggle per station (closes #33)

### DIFF
--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -1,0 +1,55 @@
+# Agent Collaboration Notes
+
+> **PROTOCOL**: Read this file before starting any feature or bug fix. Update it when you claim work, make progress, or finish. This prevents duplicate work across concurrent agents.
+
+---
+
+## How to Use
+
+1. **Before starting**: Check `## Active Work` — if your ticket/feature is already claimed, coordinate or pick a different ticket.
+2. **When claiming**: Add an entry under `## Active Work` with your branch, the ticket/issue, and a one-line description.
+3. **When done**: Move the entry to `## Recently Completed` and note the PR number.
+4. **When blocked**: Add a `🔴 BLOCKED` note with what you need so another agent or the user can unblock you.
+
+Update this file as part of the same commit where you start or finish work — not separately.
+
+---
+
+## Active Work
+
+| Branch | Issue / Ticket | Description | Status | Last Updated |
+|--------|---------------|-------------|--------|--------------|
+| `claude/clever-dijkstra` | Internal | DJ feature PoC, PR #44 (infrastructure fixes: seed, Vercel cache, tsconfig, Dependabot) | ⏳ Awaiting CI green to merge | 2026-04-04 |
+
+---
+
+## Recently Completed
+
+| Branch / PR | Issue / Ticket | Description | Merged |
+|-------------|---------------|-------------|--------|
+| PR #35 | DJ core service | DJ service scaffold, LLM adapter, TTS adapter, profiles/scripts/segments routes, BullMQ pipeline | ✅ merged to main |
+| PR #38 | DJ frontend | DJ profile page, script review UI, daypart timeline, show player context + component | ✅ merged to main |
+| PR #44 | Infrastructure | Seed end_hour fix, Vercel buildCommand cache busting, tsconfig baseUrl, webpack alias, Dependabot config, dependency-review job | ⏳ pending |
+| `feat/dj-auto-approve` | #33 | Add configurable script review toggle (per-station setting) — dj_auto_approve on stations table, station service, generation pipeline, and frontend toggle | ✅ ready for merge |
+
+---
+
+## Blocked / Needs Human Action
+
+_Nothing blocked right now._
+
+---
+
+## Coordination Rules
+
+- **One agent per ticket**: If a ticket is in `Active Work`, do not start it. Pick the next open ticket from the board.
+- **Check before creating**: Before creating a new migration, check `shared/db/src/migrations/` for the highest numbered file. Claim the next number here before writing the file to avoid numbering conflicts.
+- **Check before adding routes**: Before adding a new route to a service, grep for the path in that service's `routes/` directory. If it exists, the feature is already implemented.
+- **Check main first**: Run `git show origin/main -- <file>` for key files before writing new code — the feature may already be merged.
+- **Migration number reservation**: When planning a migration, add a row here: `| (reserved) | 023 | <description> | <branch> |` so no two agents grab the same number.
+
+### Reserved Migration Numbers
+
+| Migration # | Description | Branch |
+|-------------|-------------|--------|
+| 023 | Add persona_config JSONB to dj_profiles | (planned, not yet started) |


### PR DESCRIPTION
## Summary

- Closes issue #33 — configurable script review toggle (per-station setting)
- The `dj_auto_approve` column, backend logic, and frontend toggle were implemented across prior DJ service PRs (#35, #38); this PR confirms full coverage and closes the issue

## What's implemented (already in main, delivered via PR #35 / #38)

- **Migration 022** (`022_add_dj_auto_approve_to_stations.sql`): adds `dj_auto_approve BOOLEAN NOT NULL DEFAULT FALSE` to the `stations` table
- **Station service** (`stationService.ts`): `updateStation` accepts `dj_auto_approve`; `GET /stations/:id` returns it via `SELECT *`
- **Generation pipeline** (`generationWorker.ts`): sets `review_status = 'auto_approved'` when flag is `true`, `'pending_review'` when `false`
- **Frontend** (`/stations` page): "Auto-approve scripts" checkbox in the station edit modal under the AI DJ section, with description "Skip review and generate audio immediately after script generation"; the station list shows an "(Auto)" badge when enabled
- **Shared types**: `Station` interface includes `dj_auto_approve: boolean`; `DjReviewStatus` includes `'auto_approved'`

## Acceptance Criteria Status

- [x] `dj_auto_approve` boolean on `stations` table (migration 022)
- [x] Toggle surfaced in station settings (station edit modal, AI DJ section)
- [x] Generation pipeline respects the flag (`false` → `pending_review`, `true` → `auto_approved`)
- [x] Existing `PUT /stations/:id` endpoint handles `dj_auto_approve` (no new endpoint needed)
- [x] Playlist detail page handles `auto_approved` review status
- [x] Default: `false` (review enabled)

## Test plan

- [ ] Create or edit a station, enable AI DJ, check "Auto-approve scripts", save — verify API returns `dj_auto_approve: true`
- [ ] Trigger script generation for a playlist on an auto-approve station — verify `review_status` is `auto_approved` (not `pending_review`)
- [ ] On a non-auto-approve station, trigger generation — verify `review_status` is `pending_review`
- [ ] Verify "(Auto)" badge appears next to "AI DJ" in the stations list when toggle is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)