### PR TITLE
feat(nav): add DJ link to sidebar navigation

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -34,6 +34,14 @@ const NAV_LINKS = [
     ),
   },
   {
+    href: '/dj', label: 'DJ',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"/>
+      </svg>
+    ),
+  },
+  {
     href: '/playlists', label: 'Playlists',
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -18,6 +18,7 @@ Before starting any task, an agent MUST:
 ## Active Work
 
 ## Recently Completed
+- [x] Add DJ link to sidebar navigation (issue #103, feat/dj-sidebar-nav) | @claude-code | 2026-04-04
 - [x] DJ Personality Feature (persona_config JSONB, PersonaConfig type, prompt builder, seed, frontend form) | @claude-code | 2026-04-04
 - [x] Fix @fastify/rate-limit v10→v9 for Fastify v4 compatibility (DJ + Station services) | @claude-code | 2026-04-04
 - [x] Make AI DJ API keys configurable in Station Settings UI/Backend | @gemini-cli | 2026-04-04


### PR DESCRIPTION
## Summary
- Adds a **DJ** nav link to the sidebar between Templates and Playlists
- Uses a microphone SVG icon matching the style of existing nav icons
- Routes to `/dj` which already exists in the frontend build
- Closes #103

## Test plan
- [ ] Verify DJ link appears in sidebar between Templates and Playlists
- [ ] Clicking DJ link navigates to `/dj`
- [ ] Active state highlights correctly when on `/dj` or any sub-path
- [ ] Mobile sidebar also shows the DJ link
- [ ] Frontend build passes (`pnpm --filter frontend build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)