### PR TITLE
feat(dj): implement script template management UI

### DIFF
--- a/frontend/src/app/stations/[id]/dj/page.tsx
+++ b/frontend/src/app/stations/[id]/dj/page.tsx
@@ -5,7 +5,53 @@ import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { getCurrentUser } from '@/lib/auth';
 import { api } from '@/lib/api';
-import type { ApiError, DjProfile, TtsProvider, PersonaConfig, DjScriptTemplate, DjSegmentType } from '@playgen/types';
+import type { ApiError } from '@/lib/api';
+
+type TtsProvider = 'openai' | 'elevenlabs';
+type DjSegmentType =
+  | 'show_intro'
+  | 'song_intro'
+  | 'song_transition'
+  | 'show_outro'
+  | 'station_id'
+  | 'time_check'
+  | 'weather_tease'
+  | 'ad_break';
+
+interface PersonaConfig {
+  catchphrases?: string[];
+  signature_greeting?: string;
+  signature_signoff?: string;
+  topics_to_avoid?: string[];
+  energy_level?: number;
+  humor_level?: number;
+  formality?: 'casual' | 'balanced' | 'formal';
+  backstory?: string;
+}
+
+interface DjProfile {
+  id: string;
+  company_id: string;
+  name: string;
+  personality: string;
+  voice_style: string;
+  persona_config: PersonaConfig;
+  llm_model: string;
+  llm_temperature: number;
+  tts_provider: TtsProvider;
+  tts_voice_id: string;
+  is_default: boolean;
+  is_active: boolean;
+}
+
+interface DjScriptTemplate {
+  id: string;
+  station_id: string;
+  segment_type: DjSegmentType;
+  name: string;
+  prompt_template: string;
+  is_active: boolean;
+}
 
 interface Voice {
   id: string;


### PR DESCRIPTION
This PR adds a comprehensive management interface for DJ script templates, meeting all acceptance criteria for #20.

### Changes
- **Frontend**:
  - New **Script Templates** tab on the DJ Management page.
  - Templates are grouped by **Segment Type** (segue, song_intro, etc.).
  - Detailed **Create/Edit Template** modal with a **Variables Reference Panel**.
  - Available variables: `{{station_name}}`, `{{dj_name}}`, `{{song_title}}`, etc.
  - Delete operation with confirmation.
- **Backend**:
  - Added `DELETE /dj/stations/:stationId/script-templates/:id` endpoint.
  - Implemented `deleteTemplate` in `scriptTemplateService`.

### Validation
- Verified CRUD operations locally.
- Verified grouping and variable insertion logic.