### PR TITLE
feat(station): seed default DJ profile and daypart assignments for new stations

### DIFF
--- a/services/station/src/services/djSetupService.ts
+++ b/services/station/src/services/djSetupService.ts
@@ -1,0 +1,109 @@
+import { getPool } from '../db';
+
+const DEFAULT_ALEX_PERSONALITY =
+  "You are Alex, an upbeat and charismatic radio DJ who loves music and connecting with listeners. " +
+  "You have a warm, friendly tone with just the right amount of energy — never over-the-top but always engaging. " +
+  "You know your music deeply: the artists, the stories, the eras. You keep things moving, " +
+  "bridge songs naturally, and make every listener feel like they're tuning in to their favourite station.";
+
+const DEFAULT_PERSONA_CONFIG = {
+  catchphrases: [
+    "Keep it locked right here!",
+    "That's what I'm talking about!",
+    "Let's keep the good times rolling!",
+  ],
+  signature_greeting: "Hey hey hey, you're live with Alex on {{station_name}}!",
+  signature_signoff: "Stay tuned, stay awesome, and remember — the best music is right here.",
+  topics_to_avoid: ["politics", "religion", "controversial news"],
+  energy_level: 7,
+  humor_level: 6,
+  formality: "casual",
+  backstory:
+    "Alex has been in radio for over a decade, starting as an intern at a college station. " +
+    "Known for incredible music taste spanning genres and a knack for making every listener " +
+    "feel like they're the only one tuning in. Off air, Alex is a vinyl collector and " +
+    "weekend festival-goer who brings that live-music energy to every broadcast.",
+};
+
+const DAYPARTS = [
+  { daypart: 'overnight',  start_hour: 0,  end_hour: 6  },
+  { daypart: 'morning',    start_hour: 6,  end_hour: 12 },
+  { daypart: 'midday',     start_hour: 12, end_hour: 15 },
+  { daypart: 'afternoon',  start_hour: 15, end_hour: 19 },
+  { daypart: 'evening',    start_hour: 19, end_hour: 23 },
+] as const;
+
+/**
+ * Ensures a default DJ profile ("Alex") exists for the given company, then
+ * creates daypart assignments mapping all time slots to that profile for the
+ * given station. Safe to call multiple times — uses ON CONFLICT DO NOTHING.
+ */
+export async function seedDefaultDjProfileForStation(
+  companyId: string,
+  stationId: string,
+): Promise<void> {
+  const pool = getPool();
+
+  // Check whether the dj_profiles table exists (guard for environments where
+  // DJ migrations haven't been applied yet)
+  const tableCheck = await pool.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables WHERE table_name = 'dj_profiles'
+     ) AS exists`,
+  );
+  if (!tableCheck.rows[0]?.exists) {
+    console.warn('[station] dj_profiles table not found — skipping DJ profile seed.');
+    return;
+  }
+
+  // Find or create the default DJ profile for this company
+  const existingProfile = await pool.query<{ id: string }>(
+    'SELECT id FROM dj_profiles WHERE company_id = $1 AND is_default = TRUE LIMIT 1',
+    [companyId],
+  );
+
+  let profileId: string;
+
+  if (existingProfile.rowCount && existingProfile.rowCount > 0) {
+    profileId = existingProfile.rows[0].id;
+    console.log(`[station] Reusing existing default DJ profile ${profileId} for company ${companyId}`);
+  } else {
+    // Create the default "Alex" profile for this company
+    const inserted = await pool.query<{ id: string }>(
+      `INSERT INTO dj_profiles (
+         company_id, name, personality, voice_style, persona_config,
+         llm_model, llm_temperature, tts_provider, tts_voice_id,
+         is_default, is_active
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       RETURNING id`,
+      [
+        companyId,
+        'Alex',
+        DEFAULT_ALEX_PERSONALITY,
+        'energetic',
+        JSON.stringify(DEFAULT_PERSONA_CONFIG),
+        'anthropic/claude-sonnet-4-5',
+        0.80,
+        'openai',
+        'alloy',
+        true,
+        true,
+      ],
+    );
+    profileId = inserted.rows[0].id;
+    console.log(`[station] Created default DJ profile "Alex" (${profileId}) for company ${companyId}`);
+  }
+
+  // Create daypart assignments for the new station
+  for (const { daypart, start_hour, end_hour } of DAYPARTS) {
+    await pool.query(
+      `INSERT INTO dj_daypart_assignments
+         (station_id, dj_profile_id, daypart, start_hour, end_hour)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (station_id, daypart) DO NOTHING`,
+      [stationId, profileId, daypart, start_hour, end_hour],
+    );
+  }
+
+  console.log(`[station] Default daypart assignments seeded for station ${stationId}`);
+}

--- a/services/station/src/services/stationService.ts
+++ b/services/station/src/services/stationService.ts
@@ -1,5 +1,6 @@
 import { getPool } from '../db';
 import { Station } from '@playgen/types';
+import { seedDefaultDjProfileForStation } from './djSetupService';
 
 export async function listStations(companyId: string): Promise<Station[]> {
   const { rows } = await getPool().query<Station>(
@@ -40,6 +41,12 @@ export async function createStation(data: {
     'INSERT INTO rotation_rules (station_id) VALUES ($1) ON CONFLICT DO NOTHING',
     [rows[0].id]
   );
+
+  // Seed default DJ profile and daypart assignments for the new station
+  // This is fire-and-forget — a failure here should not block station creation
+  seedDefaultDjProfileForStation(data.company_id, rows[0].id).catch((err) => {
+    console.error('[station] Failed to seed default DJ profile:', err);
+  });
 
   return rows[0];
 }

--- a/services/station/tests/unit/djSetupService.test.ts
+++ b/services/station/tests/unit/djSetupService.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the DB module before importing the service under test
+const mockQuery = vi.fn();
+
+vi.mock('../../src/db', () => ({
+  getPool: vi.fn(() => ({ query: mockQuery })),
+}));
+
+import { seedDefaultDjProfileForStation } from '../../src/services/djSetupService';
+
+const COMPANY_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const STATION_ID = 'bbbbbbbb-0000-0000-0000-000000000001';
+const PROFILE_ID = 'cccccccc-0000-0000-0000-000000000001';
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe('seedDefaultDjProfileForStation', () => {
+  it('skips gracefully when dj_profiles table does not exist', async () => {
+    // Table existence check returns false
+    mockQuery.mockResolvedValueOnce({ rows: [{ exists: false }] });
+
+    await seedDefaultDjProfileForStation(COMPANY_ID, STATION_ID);
+
+    // Only one query should have been made (the table existence check)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses existing default profile and seeds daypart assignments', async () => {
+    // 1. Table exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ exists: true }] });
+    // 2. Existing default profile found
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: PROFILE_ID }] });
+    // 3-7. Five daypart inserts (ON CONFLICT DO NOTHING)
+    for (let i = 0; i < 5; i++) {
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    }
+
+    await seedDefaultDjProfileForStation(COMPANY_ID, STATION_ID);
+
+    // Should not have inserted a new profile
+    const calls = mockQuery.mock.calls.map(([sql]: [string]) => sql.trim().split('\n')[0].trim());
+    expect(calls.some(c => c.startsWith('INSERT INTO dj_profiles'))).toBe(false);
+
+    // Should have inserted 5 daypart assignments
+    const daypartInserts = mockQuery.mock.calls.filter(([sql]: [string]) =>
+      sql.includes('dj_daypart_assignments'),
+    );
+    expect(daypartInserts).toHaveLength(5);
+  });
+
+  it('creates a new default DJ profile when none exists for the company', async () => {
+    // 1. Table exists
+    mockQuery.mockResolvedValueOnce({ rows: [{ exists: true }] });
+    // 2. No existing default profile
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    // 3. Insert new profile returns id
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: PROFILE_ID }] });
+    // 4-8. Five daypart inserts
+    for (let i = 0; i < 5; i++) {
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    }
+
+    await seedDefaultDjProfileForStation(COMPANY_ID, STATION_ID);
+
+    const profileInsert = mockQuery.mock.calls.find(([sql]: [string]) =>
+      sql.includes('INSERT INTO dj_profiles'),
+    );
+    expect(profileInsert).toBeDefined();
+
+    // Profile insert should include is_default = true
+    expect(profileInsert![1]).toContain(true); // is_default
+
+    // 5 daypart inserts
+    const daypartInserts = mockQuery.mock.calls.filter(([sql]: [string]) =>
+      sql.includes('dj_daypart_assignments'),
+    );
+    expect(daypartInserts).toHaveLength(5);
+  });
+
+  it('seeds all 5 standard dayparts (overnight, morning, midday, afternoon, evening)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ exists: true }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: PROFILE_ID }] });
+    for (let i = 0; i < 5; i++) {
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    }
+
+    await seedDefaultDjProfileForStation(COMPANY_ID, STATION_ID);
+
+    const daypartCalls = mockQuery.mock.calls.filter(([sql]: [string]) =>
+      sql.includes('dj_daypart_assignments'),
+    );
+
+    const dayparts = daypartCalls.map(([, params]: [string, unknown[]]) => params[2]);
+    expect(dayparts).toContain('overnight');
+    expect(dayparts).toContain('morning');
+    expect(dayparts).toContain('midday');
+    expect(dayparts).toContain('afternoon');
+    expect(dayparts).toContain('evening');
+  });
+});


### PR DESCRIPTION
## Summary

- When a station is created, fires-and-forgets a seed that creates a default "Alex" DJ profile for the company (if one doesn't exist yet)
- Assigns all 5 daypart slots (overnight/morning/midday/afternoon/evening) to that profile for the new station
- Safe to call multiple times — uses `ON CONFLICT DO NOTHING`
- Guard clause skips gracefully in environments where DJ migrations haven't been applied

## Test plan

- [ ] Create a new station → verify `dj_profiles` row exists for the company with Alex persona
- [ ] Verify `dj_daypart_assignments` has 5 rows for the new station
- [ ] Create a second station in the same company → verify existing profile is reused (no duplicate)
- [ ] Unit tests: `pnpm --filter @playgen/station-service test:unit`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)