### PR TITLE
fix(cd): remove working-directory from Vercel deploy to fix doubled path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,7 +116,6 @@ jobs:
           cache: pnpm
 
       - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-        working-directory: frontend
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Vercel deploy was failing with `The provided path "frontend/frontend" does not exist`
- Root cause: `working-directory: frontend` in the workflow step + Vercel project configured with `Root Directory: frontend` = doubled path
- Fix: remove `working-directory: frontend` — Vercel CLI uses its project's configured root directory

## Test plan
- [ ] CD workflow triggers on merge to main
- [ ] Vercel deploy step succeeds without path error
- [ ] Frontend deploys to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)