### PR TITLE
docs(changelog): add v1.22 Vercel CD fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 ### Added
 - **Dashboard Stats Endpoint**: `GET /api/v1/dashboard/stats` on analytics service returns `active_songs`, `todays_playlists`, `pending_approvals`, and `active_stations` in a single query, scoped to the caller's company; fixes 500 errors on the dashboard stats cards (#118)
 
+### Fixed
+- **Vercel CD doubled path**: Removed `working-directory: frontend` from Vercel deploy step in `cd.yml` to fix doubled `frontend/frontend` path causing deploy failures (#119)
+
 ---
 
 ## [1.21] - 2026-04-04


### PR DESCRIPTION
## Summary

- Adds the missing `#119` entry to the `[1.22]` CHANGELOG section for the Vercel CD doubled path fix

This was omitted when PR #119 was merged directly without a CHANGELOG update on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)