### PR TITLE
fix(cd): add --cwd frontend to vercel deploy to fix @tailwindcss/postcss error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -115,7 +115,7 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --cwd frontend
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 ### Added
 - **Dashboard Stats Endpoint**: `GET /api/v1/dashboard/stats` on analytics service returns `active_songs`, `todays_playlists`, `pending_approvals`, and `active_stations` in a single query, scoped to the caller's company; fixes 500 errors on the dashboard stats cards (#118)
 
+### Fixed
+- **Vercel CD doubled path**: Removed `working-directory: frontend` from Vercel deploy step in `cd.yml` to fix doubled `frontend/frontend` path causing deploy failures (#119)
+- **Vercel CD missing cwd**: Added `--cwd frontend` to `vercel deploy` command so the CLI resolves the correct project root after the `working-directory` removal
+
 ---
 
 ## [1.21] - 2026-04-04


### PR DESCRIPTION
## Summary

- After PR #119 removed `working-directory: frontend` from the Vercel deploy step, `vercel deploy` now runs from the monorepo root
- Without `--cwd frontend`, Vercel CLI doesn't know the project root is `frontend/`, so it misresolves `vercel.json` and the pnpm lock file detection
- Vercel's build environment falls back to `npm install` from the wrong directory, causing `@tailwindcss/postcss` not found error
- Fix: add `--cwd frontend` flag to `npx vercel deploy` so the CLI resolves the correct project directory
- Also adds the missing CHANGELOG entries for #119 and this follow-up fix

## Test plan
- [ ] CD pipeline on main should pass the Deploy Frontend step after merge
- [ ] Vercel build log should show pnpm install succeeding and Next.js build completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)