### PR TITLE
feat(dj): add configurable auto-approve toggle to DJ management page

### DIFF
--- a/services/station/tests/unit/djAutoApprove.test.ts
+++ b/services/station/tests/unit/djAutoApprove.test.ts
@@ -50,13 +50,12 @@ describe('stationService — dj_auto_approve toggle', () => {
     expect(values).toContain(false);
   });
 
-  it('does not update when only dj_auto_approve and nothing else is different — still returns station', async () => {
-    // When fields array is empty (no updates), getStation is called instead
+  it('returns station unchanged when no update fields are provided', async () => {
     const existing = { id: 'station-1', name: 'Test FM', dj_auto_approve: false };
     mockQuery.mockResolvedValueOnce({ rows: [existing] });
 
     const result = await stationService.updateStation('station-1', {});
-    // getStation called with SELECT
+    // When no fields are updated, getStation is called (SELECT query)
     const sql = mockQuery.mock.calls[0][0] as string;
     expect(sql).toContain('SELECT');
     expect(result).not.toBeNull();

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -15,7 +15,7 @@ Before starting any task, an agent MUST:
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05
 
 ## Recently Completed
-- [x] Auth flows — password reset, user invite, admin force-reset (issues #127, #128, #129, #131, PR #145) | @claude-code | 2026-04-05
+- [x] Auto-approve script review toggle (issue #33, PR #135) | @claude-code | 2026-04-05
 - [x] Category distribution by date + bar chart (issue #134, PR #143) | @claude-code | 2026-04-05
 - [x] Day-of-week template overrides (issue #130, PR #138) | @claude-code | 2026-04-05
 - [x] Re-generate single slot (issue #132, PR #140) | @claude-code | 2026-04-05


### PR DESCRIPTION
## Summary

Closes #33

- **Generation Settings section** on `/stations/:id/dj` page with an auto-approve toggle switch
- Toggle calls `PUT /api/v1/stations/:id` with `{ dj_auto_approve: true/false }` (already supported by station service)
- Loads current setting from station API on page mount so the toggle reflects actual state
- **Amber warning** when enabled: "Scripts will not be reviewed before audio is generated"
- **Playlist detail**: generating in-progress message updates based on station setting:
  - Auto-approve off: "Generating DJ script via OpenRouter…"
  - Auto-approve on: "Generating DJ script and audio…"

The backend (DB column, station service `updateStation`, worker TTS gating) was already implemented in prior PRs.

## Test plan

- [x] 3 unit tests for `stationService.updateStation` dj_auto_approve toggle — all pass
- [x] `pnpm run typecheck` passes clean across all services and frontend
- [x] All 19 station service unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)