### PR TITLE
fix(cd): add shamefully-hoist=true .npmrc to fix Vercel pnpm module resolution

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -115,7 +115,7 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --cwd frontend
+      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ### Fixed
 - **CD Pipeline**: Switch Vercel `installCommand` from `npm install` to `pnpm install --frozen-lockfile` and `buildCommand` to `pnpm run build` to match the pnpm monorepo setup and fix Vercel production deploy failures
+- **Vercel pnpm module resolution**: Add root `.npmrc` with `shamefully-hoist=true` so pnpm hoists all packages to root `node_modules`, allowing `@tailwindcss/postcss` and other devDependencies to be resolved correctly during Vercel's monorepo build; remove `--cwd frontend` from `vercel deploy` command
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a root `.npmrc` with `shamefully-hoist=true` so pnpm hoists all packages to the root `node_modules/`, fixing `@tailwindcss/postcss` not found during Vercel's monorepo build
- Reverts `--cwd frontend` from `vercel deploy` command (introduced in #124) which conflicted with Vercel project's `Root Directory: frontend` setting, causing a doubled `frontend/frontend/` path error

## Root cause

In pnpm's default isolated mode, packages are symlinked from a virtual store. Vercel's build environment (running `next build` from `frontend/`) could not resolve `@tailwindcss/postcss` (a devDependency) through pnpm's symlinks. With `shamefully-hoist=true`, pnpm hoists all packages flat to `node_modules/`, making them directly accessible.

## Test plan
- [ ] CD pipeline on main — Deploy Frontend step succeeds
- [ ] No more `Cannot find module '@tailwindcss/postcss'` error in Vercel build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)