### PR TITLE
fix(cd): remove --cwd frontend from Vercel deploy command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -115,7 +115,7 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --cwd frontend
+      - run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.25] - 2026-04-05
+
+### Fixed
+- **CD Pipeline**: Remove `--cwd frontend` from Vercel deploy command (re-introduced by another agent); Vercel dashboard already has `Root Directory: frontend` configured so `--cwd frontend` caused a doubled `frontend/frontend` path error
+
+---
+
 ## [1.23] - 2026-04-05
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Removes `--cwd frontend` from the Vercel deploy step in `cd.yml`
- Root cause: another agent re-added `--cwd frontend` while trying to fix the npm/pnpm issue; Vercel's project dashboard already has `Root Directory: frontend` configured, so passing `--cwd frontend` doubles the path to `frontend/frontend` causing the error: `The provided path ".../frontend/frontend" does not exist`
- This is a re-fix of what PR #119 already corrected

## Test plan
- [ ] CD pipeline on main runs Vercel deploy successfully with no path errors
- [ ] Frontend deploys to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)