### PR TITLE
feat(library): day-of-week template overrides GET/PUT + builder UI selector

### DIFF
--- a/frontend/src/app/templates/[id]/builder/page.tsx
+++ b/frontend/src/app/templates/[id]/builder/page.tsx
@@ -33,6 +33,17 @@ interface TemplateWithSlots extends Template {
   slots: TemplateSlot[];
 }
 
+const DAYS_OF_WEEK = [
+  'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday',
+] as const;
+type DayKey = typeof DAYS_OF_WEEK[number];
+type DayOverrides = Record<DayKey, string | null>;
+
+const EMPTY_OVERRIDES: DayOverrides = {
+  monday: null, tuesday: null, wednesday: null, thursday: null,
+  friday: null, saturday: null, sunday: null,
+};
+
 const CATEGORY_COLORS = [
   'bg-violet-900/40 text-violet-300 border-violet-500/30',
   'bg-blue-900/40 text-blue-300 border-blue-500/30',
@@ -75,6 +86,12 @@ export default function TemplateBuilderPage() {
 
   const [openCell, setOpenCell] = useState<string | null>(null);
 
+  // Day-of-week overrides state
+  const [dayOverrides, setDayOverrides] = useState<DayOverrides>(EMPTY_OVERRIDES);
+  const [stationTemplates, setStationTemplates] = useState<Template[]>([]);
+  const [overridesSaving, setOverridesSaving] = useState(false);
+  const [overridesSaved, setOverridesSaved] = useState(false);
+
   const categoryColorMap = new Map<string, string>();
   categories.forEach((c, idx) => {
     categoryColorMap.set(c.id, CATEGORY_COLORS[idx % CATEGORY_COLORS.length]);
@@ -98,8 +115,14 @@ export default function TemplateBuilderPage() {
       const { slots: rawSlots, ...tpl } = tplWithSlots;
       setTemplate(tpl);
 
-      const cats = await api.get<Category[]>(`/api/v1/stations/${tpl.station_id}/categories`);
+      const [cats, allTpls, overridesRes] = await Promise.all([
+        api.get<Category[]>(`/api/v1/stations/${tpl.station_id}/categories`),
+        api.get<Template[]>(`/api/v1/stations/${tpl.station_id}/templates`),
+        api.get<{ overrides: DayOverrides }>(`/api/v1/templates/${templateId}/day-overrides`),
+      ]);
       setCategories(cats);
+      setStationTemplates(allTpls.filter((t) => t.id !== templateId));
+      setDayOverrides({ ...EMPTY_OVERRIDES, ...overridesRes.overrides });
 
       const map = new Map<string, string | null>();
       rawSlots.forEach((slot) => {
@@ -144,6 +167,21 @@ export default function TemplateBuilderPage() {
       setError((err as ApiError).message ?? 'Failed to save template');
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleSaveOverrides() {
+    setOverridesSaving(true);
+    setOverridesSaved(false);
+    setError(null);
+    try {
+      await api.put<{ overrides: DayOverrides }>(`/api/v1/templates/${templateId}/day-overrides`, dayOverrides);
+      setOverridesSaved(true);
+      setTimeout(() => setOverridesSaved(false), 3000);
+    } catch (err: unknown) {
+      setError((err as ApiError).message ?? 'Failed to save day overrides');
+    } finally {
+      setOverridesSaving(false);
     }
   }
 
@@ -205,12 +243,58 @@ export default function TemplateBuilderPage() {
         </div>
       )}
 
-      {/* Grid */}
-      <div className="card overflow-x-auto">
-        <table className="min-w-full text-sm border-collapse">
+      {/* Day-of-week overrides section */}
+      <div className="mb-6 bg-[#16161f] border border-[#2a2a40] rounded-xl p-5">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Day-of-Week Overrides</h2>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Assign a different template to use on specific days. Leave blank to use this template.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {overridesSaved && <span className="text-xs text-green-400">Saved!</span>}
+            <button
+              onClick={handleSaveOverrides}
+              disabled={overridesSaving}
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-violet-600 hover:bg-violet-700 text-white disabled:opacity-50 transition-colors"
+            >
+              {overridesSaving ? 'Saving…' : 'Save Overrides'}
+            </button>
+          </div>
+        </div>
+        <div className="grid grid-cols-7 gap-2">
+          {DAYS_OF_WEEK.map((day) => (
+            <div key={day} className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-gray-400 capitalize">{day.slice(0, 3)}</label>
+              <select
+                value={dayOverrides[day] ?? ''}
+                onChange={(e) =>
+                  setDayOverrides((prev) => ({
+                    ...prev,
+                    [day]: e.target.value === '' ? null : e.target.value,
+                  }))
+                }
+                className="w-full rounded-lg bg-[#1c1c28] border border-[#2a2a40] text-gray-300 text-xs px-2 py-1.5 focus:outline-none focus:border-violet-500"
+              >
+                <option value="">— this template —</option>
+                {stationTemplates.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Slot grid */}
+      <div className="overflow-x-auto rounded-xl border border-[#2a2a40]">
+        <table className="w-full text-sm text-left">
           <thead>
-            <tr className="bg-[#13131a]">
-              <th className="px-3 py-2.5 text-left text-xs font-semibold text-gray-500 uppercase w-20 border-b border-[#2a2a40]">
+            <tr className="border-b border-[#2a2a40] bg-[#16161f]">
+              <th className="px-3 py-2.5 text-xs font-semibold text-gray-500 uppercase border-b border-[#2a2a40]">
                 Hour
               </th>
               {POSITIONS.map((p) => (

--- a/services/library/tests/integration/dayOverrides.test.ts
+++ b/services/library/tests/integration/dayOverrides.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for template day-of-week overrides.
+ *
+ * Runs against a real PostgreSQL database, skipped unless TEST_DATABASE_URL is set.
+ *
+ * To run locally:
+ *   TEST_DATABASE_URL=postgres://playgen:changeme@localhost:5432/playgen_test \
+ *     pnpm --filter @playgen/library-service test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import {
+  createTemplate,
+  getDayOverrides,
+  setDayOverrides,
+} from '../../src/services/templateService';
+
+// ─── Database bootstrap ────────────────────────────────────────────────────────
+
+function applyTestDatabaseUrl(): void {
+  const raw = process.env.TEST_DATABASE_URL;
+  if (!raw) return;
+  try {
+    const url = new URL(raw);
+    process.env.POSTGRES_HOST = url.hostname;
+    process.env.POSTGRES_PORT = url.port || '5432';
+    process.env.POSTGRES_DB = url.pathname.replace(/^\//, '');
+    process.env.POSTGRES_USER = url.username;
+    process.env.POSTGRES_PASSWORD = url.password;
+  } catch {
+    // leave as-is
+  }
+}
+
+applyTestDatabaseUrl();
+
+// ─── Test fixture state ────────────────────────────────────────────────────────
+
+let pool: Pool;
+let testCompanyId: string;
+let testStationId: string;
+let templateId: string;
+let altTemplateId: string;
+
+// ─── Setup / Teardown ──────────────────────────────────────────────────────────
+
+describe.skipIf(!process.env.TEST_DATABASE_URL)('Day-of-week overrides integration tests', () => {
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: process.env.TEST_DATABASE_URL });
+
+    const companyRes = await pool.query<{ id: string }>(
+      `INSERT INTO companies (name, slug)
+       VALUES ('DOW Override Test Co', 'dow-override-test-co-${Date.now()}')
+       RETURNING id`,
+    );
+    testCompanyId = companyRes.rows[0].id;
+
+    const stationRes = await pool.query<{ id: string }>(
+      `INSERT INTO stations (company_id, name, slug, timezone)
+       VALUES ($1, 'DOW Test Station', 'dow-test-station-${Date.now()}', 'UTC')
+       RETURNING id`,
+      [testCompanyId],
+    );
+    testStationId = stationRes.rows[0].id;
+
+    const tpl = await createTemplate({ station_id: testStationId, name: 'Base Template', type: '1_day' });
+    templateId = tpl.id;
+    const alt = await createTemplate({ station_id: testStationId, name: 'Alt Template', type: '1_day' });
+    altTemplateId = alt.id;
+  });
+
+  afterAll(async () => {
+    // Templates cascade on station delete; deleting company cascades everything
+    await pool.query('DELETE FROM companies WHERE id = $1', [testCompanyId]);
+    await pool.end();
+  });
+
+  // ─── Happy path ─────────────────────────────────────────────────────────────
+
+  it('getDayOverrides returns all-null map for a fresh template', async () => {
+    const overrides = await getDayOverrides(templateId);
+    expect(overrides).not.toBeNull();
+    const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    for (const day of days) {
+      expect((overrides as Record<string, unknown>)[day]).toBeNull();
+    }
+  });
+
+  it('setDayOverrides persists specific day overrides', async () => {
+    const updated = await setDayOverrides(templateId, {
+      monday: altTemplateId,
+      friday: altTemplateId,
+    });
+    expect(updated).not.toBeNull();
+    expect(updated!.monday).toBe(altTemplateId);
+    expect(updated!.friday).toBe(altTemplateId);
+    expect(updated!.tuesday).toBeNull();
+    expect(updated!.saturday).toBeNull();
+  });
+
+  it('getDayOverrides reflects persisted values', async () => {
+    const overrides = await getDayOverrides(templateId);
+    expect(overrides!.monday).toBe(altTemplateId);
+    expect(overrides!.friday).toBe(altTemplateId);
+    expect(overrides!.wednesday).toBeNull();
+  });
+
+  it('setDayOverrides with null clears a day override', async () => {
+    const updated = await setDayOverrides(templateId, { monday: null });
+    expect(updated!.monday).toBeNull();
+    // friday override should still be set
+    expect(updated!.friday).toBe(altTemplateId);
+  });
+
+  // ─── Not-found / tenant isolation ───────────────────────────────────────────
+
+  it('getDayOverrides returns null for non-existent template', async () => {
+    const result = await getDayOverrides('00000000-0000-0000-0000-000000000000');
+    expect(result).toBeNull();
+  });
+
+  it('setDayOverrides returns null for non-existent template', async () => {
+    const result = await setDayOverrides('00000000-0000-0000-0000-000000000000', { monday: altTemplateId });
+    expect(result).toBeNull();
+  });
+
+  it('tenant isolation: overrides on one template do not affect another', async () => {
+    const altOverrides = await getDayOverrides(altTemplateId);
+    // altTemplate was never updated, should be all-null
+    const days = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    for (const day of days) {
+      expect((altOverrides as Record<string, unknown>)[day]).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Closes #130

## Summary
- `GET /api/v1/templates/:id/day-overrides` returns `{monday..sunday: uuid|null}` from the existing `day_of_week_overrides JSONB` column
- `PUT /api/v1/templates/:id/day-overrides` accepts the same shape, validates non-null values are UUIDs, merges into JSONB (null clears a day)
- `getDayOverrides` / `setDayOverrides` added to `templateService.ts` — no DB migration needed, column already exists (migration 010)
- Frontend: "Day-of-Week Overrides" section on Template Builder page with a 7-column dropdown grid (one per day), listing all other templates for that station

## Test plan
- [ ] `pnpm --filter @playgen/library-service run build` passes (TypeScript clean)
- [ ] Integration tests in `services/library/tests/integration/dayOverrides.test.ts`: fresh template all-null, set overrides, null-clearing, not-found, tenant isolation
- [ ] Manual: open Template Builder, set Monday to a different template, click Save Overrides, reload — Monday shows saved template
- [ ] PUT with invalid UUID returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)