### PR TITLE
fix(cd): pass --shamefully-hoist to pnpm install to fix @tailwindcss/postcss in Vercel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.26] - 2026-04-05
+
+### Fixed
+- **Vercel install shameful hoist**: Pass `--shamefully-hoist` directly to the `pnpm install` command in `vercel.json` so Vercel's build environment hoists `@tailwindcss/postcss` and other devDependencies to root `node_modules/`, fixing the `Cannot find module '@tailwindcss/postcss'` error (`.npmrc`-based approach was ineffective because Vercel may override it)
+
+---
+
 ## [1.25] - 2026-04-05
 
 ### Fixed

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install --frozen-lockfile --shamefully-hoist",
   "buildCommand": "pnpm run build",
   "outputDirectory": ".next",
   "git": {


### PR DESCRIPTION
## Summary

- The `@tailwindcss/postcss` module was not being found during Vercel's production build of the frontend, even after `shamefully-hoist=true` was added to the root `.npmrc`
- Root cause: Vercel's build environment may use its own `.npmrc` or ignore the project `.npmrc` when running the configured `installCommand`, so the CLI flag approach is more reliable
- Fix: Passes `--shamefully-hoist` directly in the `installCommand` in `frontend/vercel.json` so pnpm hoists all packages (including `@tailwindcss/postcss` devDependency) to root `node_modules/`

## Test plan
- [ ] CD pipeline on main — Deploy Frontend step succeeds
- [ ] No more `Cannot find module '@tailwindcss/postcss'` in Vercel build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)