### PR TITLE
fix(cd): re-move tailwind/postcss to dependencies for Vercel build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.26] - 2026-04-05
+
+### Fixed
+- **CD Pipeline**: Re-move `tailwindcss`, `@tailwindcss/postcss`, `postcss`, and `autoprefixer` from `devDependencies` to `dependencies` in frontend `package.json` (was reverted by PR #136); Vercel's `NODE_ENV=production` causes pnpm to skip devDependencies even with `shamefully-hoist=true`
+
+---
+
 ## [1.25] - 2026-04-05
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,16 @@
   "dependencies": {
     "next": "^15.0.8",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "postcss": "^8.4.49",
+    "autoprefixer": "^10.4.20"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.4.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.4.49",
-    "autoprefixer": "^10.4.20"
+    "typescript": "^5.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,19 +30,28 @@ importers:
 
   frontend:
     dependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.2.2
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.27(postcss@8.5.8)
       next:
         specifier: ^15.0.8
         version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.8
       react:
         specifier: ^19.0.0
         version: 19.2.4
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
-    devDependencies:
-      '@tailwindcss/postcss':
+      tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
+    devDependencies:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
@@ -52,15 +61,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
-      autoprefixer:
-        specifier: ^10.4.20
-        version: 10.4.27(postcss@8.5.8)
-      postcss:
-        specifier: ^8.4.49
-        version: 8.5.8
-      tailwindcss:
-        specifier: ^4.0.0
-        version: 4.2.2
       typescript:
         specifier: ^5.4.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Re-applies the fix from PR #126 which was reverted by PR #136
- Moves `tailwindcss`, `@tailwindcss/postcss`, `postcss`, and `autoprefixer` from `devDependencies` to `dependencies` in `frontend/package.json`
- Root cause: PR #136 (shamefully-hoist .npmrc fix) included an older version of `frontend/package.json` that reverted our tailwind deps fix. `shamefully-hoist=true` does not help because pnpm still skips devDependencies when `NODE_ENV=production` regardless of hoisting
- Updated `pnpm-lock.yaml` accordingly
- Build verified locally ✓

## Test plan
- [ ] CD pipeline on main runs Vercel deploy successfully
- [ ] No `Cannot find module '@tailwindcss/postcss'` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)