### PR TITLE
feat(analytics): category distribution by date endpoint + bar chart

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -34,6 +34,13 @@ interface UnderplayedRow {
   last_played_at: string | null;
 }
 
+interface CategoryDistributionRow {
+  category_code: string;
+  category_label: string;
+  total_plays: number;
+  percentage: number;
+}
+
 function cellColor(count: number): string {
   if (count === 0) return 'bg-[#1c1c28] text-gray-600';
   if (count >= 3) return 'bg-red-900/30 text-red-400 font-semibold';
@@ -44,6 +51,21 @@ function cellColor(count: number): string {
 function shortDate(iso: string): string {
   const d = new Date(iso + 'T00:00:00');
   return d.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric' });
+}
+
+const BAR_COLORS = [
+  'bg-violet-500',
+  'bg-blue-500',
+  'bg-green-500',
+  'bg-yellow-500',
+  'bg-pink-500',
+  'bg-orange-500',
+  'bg-teal-500',
+  'bg-red-500',
+];
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
 }
 
 export default function AnalyticsPage() {
@@ -60,6 +82,12 @@ export default function AnalyticsPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Category distribution by date
+  const [distDate, setDistDate] = useState<string>(todayIso());
+  const [distribution, setDistribution] = useState<CategoryDistributionRow[]>([]);
+  const [distLoading, setDistLoading] = useState(false);
+  const [distError, setDistError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!currentUser) {
       router.replace('/login');
@@ -72,6 +100,7 @@ export default function AnalyticsPage() {
   useEffect(() => {
     if (selectedStation) {
       fetchAnalytics(selectedStation);
+      fetchDistribution(selectedStation, distDate);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStation]);
@@ -112,6 +141,26 @@ export default function AnalyticsPage() {
     }
   }
 
+  async function fetchDistribution(stationId: string, date: string) {
+    setDistLoading(true);
+    setDistError(null);
+    try {
+      const data = await api.get<CategoryDistributionRow[]>(
+        `/api/v1/stations/${stationId}/analytics/category-distribution?date=${date}`,
+      );
+      setDistribution(data);
+    } catch (err: unknown) {
+      setDistError((err as ApiError).message ?? 'Failed to load distribution');
+    } finally {
+      setDistLoading(false);
+    }
+  }
+
+  function handleDistDateChange(newDate: string) {
+    setDistDate(newDate);
+    if (selectedStation) fetchDistribution(selectedStation, newDate);
+  }
+
   const hasData = heatmap.length > 0 || overplayed.length > 0 || underplayed.length > 0;
 
   return (
@@ -140,6 +189,55 @@ export default function AnalyticsPage() {
       {error && (
         <div className="mb-4 bg-red-900/30 border border-red-700/50 text-red-400 px-4 py-3 rounded-lg text-sm">
           {error}
+        </div>
+      )}
+
+      {/* ── Category Distribution by Date ──────────────────────────────── */}
+      {selectedStation && (
+        <div className="card mb-8 p-5">
+          <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-white">Category Distribution</h2>
+              <p className="text-xs text-gray-500 mt-0.5">Scheduled songs per category on a given day</p>
+            </div>
+            <input
+              type="date"
+              value={distDate}
+              onChange={(e) => handleDistDateChange(e.target.value)}
+              className="input text-sm w-auto"
+            />
+          </div>
+
+          {distError && (
+            <p className="text-xs text-red-400 mb-3">{distError}</p>
+          )}
+
+          {distLoading ? (
+            <div className="flex justify-center py-8">
+              <div className="w-6 h-6 border-2 border-violet-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : distribution.length === 0 ? (
+            <p className="text-center text-gray-600 text-xs py-8">
+              No playlist scheduled for this date.
+            </p>
+          ) : (
+            <div className="space-y-2.5">
+              {distribution.map((row, idx) => (
+                <div key={row.category_code} className="flex items-center gap-3">
+                  <span className="text-xs text-gray-400 w-28 truncate shrink-0">{row.category_label}</span>
+                  <div className="flex-1 h-5 bg-[#1c1c28] rounded overflow-hidden">
+                    <div
+                      className={`h-full rounded ${BAR_COLORS[idx % BAR_COLORS.length]} transition-all duration-500`}
+                      style={{ width: `${row.percentage}%` }}
+                    />
+                  </div>
+                  <span className="text-xs font-semibold text-gray-300 w-16 text-right shrink-0">
+                    {row.percentage}% <span className="text-gray-600 font-normal">({row.total_plays})</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/services/analytics/src/routes/analytics.ts
+++ b/services/analytics/src/routes/analytics.ts
@@ -31,12 +31,23 @@ export async function analyticsRoutes(app: FastifyInstance) {
     return analyticsService.getUnderplayedSongs(id);
   });
 
-  // ── GET /stations/:id/analytics/category-distribution?days=7 ─────────────
+  // ── GET /stations/:id/analytics/category-distribution?days=7 ────────────
+  // ── GET /stations/:id/analytics/category-distribution?date=YYYY-MM-DD ───
   app.get('/stations/:id/analytics/category-distribution', {
     onRequest: [requirePermission('analytics:read'), requireStationAccess()],
-  }, async (req) => {
+  }, async (req, reply) => {
     const { id } = req.params as { id: string };
-    const query = req.query as { days?: string };
+    const query = req.query as { days?: string; date?: string };
+
+    if (query.date) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(query.date)) {
+        return reply.code(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'date must be in YYYY-MM-DD format' },
+        });
+      }
+      return analyticsService.getCategoryDistributionByDate(id, query.date);
+    }
+
     const days = query.days ? parseInt(query.days, 10) : 7;
     return analyticsService.getCategoryDistribution(id, days);
   });

--- a/services/analytics/src/services/analyticsService.ts
+++ b/services/analytics/src/services/analyticsService.ts
@@ -366,3 +366,61 @@ export async function getSongHistory(
     playlist_id: r.playlist_id,
   }));
 }
+
+// ─── getCategoryDistributionByDate ────────────────────────────────────────────
+
+/**
+ * Returns the percentage breakdown of scheduled songs by category for a
+ * specific date. Uses playlist_entries (planned schedule) rather than
+ * play_history, so it works even before songs have aired.
+ */
+export async function getCategoryDistributionByDate(
+  stationId: string,
+  date: string,
+): Promise<CategoryDistributionRow[]> {
+  const pool = getPool();
+
+  const sql = `
+    WITH slot_counts AS (
+      SELECT
+        COALESCE(c.code,  'UNCATEGORISED') AS category_code,
+        COALESCE(c.label, 'Uncategorised') AS category_label,
+        COUNT(*)::int                      AS total_plays
+      FROM playlist_entries pe
+      JOIN playlists         pl ON pl.id = pe.playlist_id
+      JOIN songs             s  ON s.id  = pe.song_id
+      LEFT JOIN categories   c  ON c.id  = s.category_id
+      WHERE pl.station_id = $1
+        AND pl.date       = $2
+      GROUP BY c.code, c.label
+    ),
+    grand_total AS (
+      SELECT SUM(total_plays) AS grand FROM slot_counts
+    )
+    SELECT
+      sc.category_code,
+      sc.category_label,
+      sc.total_plays,
+      CASE
+        WHEN gt.grand = 0 THEN 0
+        ELSE ROUND(sc.total_plays::numeric * 100 / gt.grand, 2)
+      END AS percentage
+    FROM slot_counts sc
+    CROSS JOIN grand_total gt
+    ORDER BY sc.total_plays DESC
+  `;
+
+  const { rows } = await pool.query<{
+    category_code: string;
+    category_label: string;
+    total_plays: number;
+    percentage: string;
+  }>(sql, [stationId, date]);
+
+  return rows.map((r) => ({
+    category_code: r.category_code,
+    category_label: r.category_label,
+    total_plays: r.total_plays,
+    percentage: Number(r.percentage),
+  }));
+}

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -12,11 +12,12 @@ Before starting any task, an agent MUST:
 
 ## Active Work
 - [ ] Fix high vulnerabilities (Next.js upgrade, Fastify upgrade, tar override) | @gemini-cli | 2026-04-04
-- [ ] Re-generate single playlist slot (issue #132, feat/issue-132-slot-regen) | @claude-code | 2026-04-05
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05
-- [ ] Category distribution report by date + chart (issue #134, feat/issue-134-category-distribution-by-date) | @claude-code | 2026-04-05
 
 ## Recently Completed
+- [x] Category distribution by date + bar chart (issue #134, PR #143) | @claude-code | 2026-04-05
+- [x] Day-of-week template overrides (issue #130, PR #138) | @claude-code | 2026-04-05
+- [x] Re-generate single slot (issue #132, PR #140) | @claude-code | 2026-04-05
 - [x] Implement GET /api/v1/dashboard/stats endpoint (issue #101, feat/dashboard-stats) | @claude-code | 2026-04-05
 - [x] Add DJ link to sidebar navigation (issue #103, feat/dj-sidebar-nav) | @claude-code | 2026-04-04
 - [x] DJ Personality Feature (persona_config JSONB, PersonaConfig type, prompt builder, seed, frontend form) | @claude-code | 2026-04-04


### PR DESCRIPTION
Closes #134

## Summary
- Extends existing `GET /api/v1/stations/:id/analytics/category-distribution` to accept `?date=YYYY-MM-DD`
- When `date` is provided: queries `playlist_entries` (planned/scheduled songs) for that specific day — useful before songs have actually aired
- When `days=N` is provided (existing behaviour): queries `play_history` as before
- 400 on invalid date format
- Frontend analytics page: new "Category Distribution" section at the top with a date picker and horizontal CSS bar chart showing `%` and slot count per category (no additional dependencies)

## Test plan
- [ ] `pnpm --filter @playgen/analytics-service run build` passes
- [ ] `cd frontend && pnpm run build` passes
- [ ] `GET /stations/{id}/analytics/category-distribution?date=2026-04-05` returns category rows with percentages
- [ ] `GET /stations/{id}/analytics/category-distribution?days=7` still works unchanged
- [ ] `GET /stations/{id}/analytics/category-distribution?date=bad-format` returns 400
- [ ] Analytics page shows date picker, select a date with a generated playlist → bars appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)