### PR TITLE
fix(frontend): move tailwindcss/postcss to dependencies to fix Vercel build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.27] - 2026-04-05
+
+### Fixed
+- **Vercel Tailwind CSS build error**: Moved `tailwindcss`, `@tailwindcss/postcss`, `postcss`, and `autoprefixer` from `devDependencies` to `dependencies` in `frontend/package.json` (and updated lockfile); these CSS build packages must be in `dependencies` so pnpm correctly exposes them in the workspace's `node_modules` scope for Next.js/PostCSS to resolve during Vercel's production build
+
+---
+
 ## [1.26] - 2026-04-05
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,16 @@
   "dependencies": {
     "next": "^15.0.8",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "postcss": "^8.4.49",
+    "autoprefixer": "^10.4.20"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.4.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.4.49",
-    "autoprefixer": "^10.4.20"
+    "typescript": "^5.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,19 +30,28 @@ importers:
 
   frontend:
     dependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.2.2
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.27(postcss@8.5.8)
       next:
         specifier: ^15.0.8
         version: 15.5.14(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.8
       react:
         specifier: ^19.0.0
         version: 19.2.4
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
-    devDependencies:
-      '@tailwindcss/postcss':
+      tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
+    devDependencies:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
@@ -52,15 +61,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
-      autoprefixer:
-        specifier: ^10.4.20
-        version: 10.4.27(postcss@8.5.8)
-      postcss:
-        specifier: ^8.4.49
-        version: 8.5.8
-      tailwindcss:
-        specifier: ^4.0.0
-        version: 4.2.2
       typescript:
         specifier: ^5.4.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Moves `tailwindcss`, `@tailwindcss/postcss`, `postcss`, and `autoprefixer` from `devDependencies` to `dependencies` in `frontend/package.json`
- Updates `pnpm-lock.yaml` to reflect the change

## Root cause

These CSS build packages are required at Next.js build time, not just during local development. When classified as `devDependencies` in a pnpm monorepo workspace, the packages are not guaranteed to be directly symlinked in `frontend/node_modules/` during production builds. Vercel's PostCSS resolution could not find `@tailwindcss/postcss` because pnpm's workspace isolation only exposes `dependencies` (not `devDependencies`) directly in the workspace's `node_modules/`.

Previous attempts (`.npmrc shamefully-hoist`, `--shamefully-hoist` flag) failed because pnpm's `--frozen-lockfile` treats devDependencies differently in workspace isolation mode.

## Test plan
- [ ] CD pipeline on main — Deploy Frontend succeeds
- [ ] No more `Cannot find module '@tailwindcss/postcss'` in Vercel build logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)