### PR TITLE
fix(cd): add outputFileTracingRoot to next.config.js for Vercel pnpm monorepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.29] - 2026-04-05
+
+### Fixed
+- **CD Pipeline**: Add `outputFileTracingRoot` to `next.config.js` pointing to the monorepo root (`../`); required for Next.js `output: 'standalone'` in a pnpm monorepo so file tracing works correctly in Vercel's remote build environment
+
+---
+
 ## [1.28] - 2026-04-05
 
 ### Fixed

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const nextConfig = {
   output: 'standalone',
+  outputFileTracingRoot: path.join(__dirname, '../'),
   webpack(config) {
     config.resolve.alias['@'] = path.resolve(__dirname, 'src');
     return config;


### PR DESCRIPTION
## Summary
- Adds `outputFileTracingRoot: path.join(__dirname, '../')` to `frontend/next.config.js`
- Root cause: Next.js `output: 'standalone'` requires `outputFileTracingRoot` to be set to the monorepo root when running in a pnpm workspace. Without this, file tracing fails silently in Vercel's remote build environment (exit code 1 with no error message after "Creating an optimized production build...")
- Build verified locally ✓

## Test plan
- [ ] CD pipeline on main: Vercel build succeeds
- [ ] Frontend deployed to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)