### PR TITLE
fix(cd): set NODE_ENV=development in vercel installCommand to include devDeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Version format: `{major}.{minor}{fix}` (e.g. `1.01`)
 
 ---
 
+## [1.29] - 2026-04-05
+
+### Fixed
+- **Vercel build skips devDeps**: Prefix `installCommand` in `vercel.json` with `NODE_ENV=development` so pnpm installs all devDependencies (typescript, @types/*) needed for `next build`'s TypeScript compilation during Vercel production deploy
+
+---
+
 ## [1.28] - 2026-04-05
 
 ### Fixed

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile --shamefully-hoist",
+  "installCommand": "NODE_ENV=development pnpm install --frozen-lockfile --shamefully-hoist",
   "buildCommand": "pnpm run build",
   "outputDirectory": ".next",
   "git": {


### PR DESCRIPTION
## Summary

- Adds `NODE_ENV=development` prefix to `installCommand` in `frontend/vercel.json`
- This ensures pnpm installs all devDependencies (typescript, @types/*) needed for `next build`'s TypeScript compilation

## Root cause

Vercel sets `NODE_ENV=production` for its build environment. When pnpm runs with `NODE_ENV=production`, it skips `devDependencies`. Even though `@tailwindcss/postcss` was moved to `dependencies` in #144, `typescript` and `@types/*` remain in `devDependencies` and are required for `next build`'s TypeScript type checking step. Without these packages, Next.js build exits with code 1.

## Test plan
- [ ] CD pipeline on main — Deploy Frontend succeeds
- [ ] `devDependencies: skipped` no longer appears in Vercel build logs
- [ ] Next.js build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)