### PR TITLE
feat(dj): script template management UI (issue #20)

### DIFF
--- a/frontend/src/app/dj/templates/page.tsx
+++ b/frontend/src/app/dj/templates/page.tsx
@@ -267,6 +267,19 @@ export default function DjTemplatesPage() {
           </p>
         </div>
       ) : (
+        <div className="space-y-4">
+          {/* Segment count summary */}
+          <div className="flex flex-wrap gap-2">
+            {SEGMENT_TYPES.filter((st) => templates.some((t) => t.segment_type === st)).map((st) => {
+              const count = templates.filter((t) => t.segment_type === st).length;
+              return (
+                <span key={st} className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs bg-[#1a1a28] border border-[#2a2a40] text-gray-400">
+                  <span className="font-mono text-violet-400">{st}</span>
+                  <span className="bg-[#2a2a40] text-gray-300 rounded-full px-1.5 py-0.5 text-[10px] font-bold">{count}</span>
+                </span>
+              );
+            })}
+          </div>
         <div className="card overflow-hidden border border-[#2a2a40]">
           <table className="w-full text-sm">
             <thead>
@@ -279,6 +292,9 @@ export default function DjTemplatesPage() {
                 </th>
                 <th className="px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden md:table-cell">
                   Prompt Preview
+                </th>
+                <th className="px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider hidden lg:table-cell">
+                  Created
                 </th>
                 <th className="px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Status
@@ -299,6 +315,13 @@ export default function DjTemplatesPage() {
                   <td className="px-4 py-3 text-white font-medium">{t.name}</td>
                   <td className="px-4 py-3 text-gray-400 hidden md:table-cell font-mono text-xs">
                     {truncate(t.prompt_template, 80)}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 text-xs hidden lg:table-cell">
+                    {new Date(t.created_at).toLocaleDateString(undefined, {
+                      year: 'numeric',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
                   </td>
                   <td className="px-4 py-3">
                     <span
@@ -331,6 +354,7 @@ export default function DjTemplatesPage() {
               ))}
             </tbody>
           </table>
+        </div>
         </div>
       )}
 

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -15,8 +15,12 @@ Before starting any task, an agent MUST:
 - [ ] Re-generate single playlist slot (issue #132, feat/issue-132-slot-regen) | @claude-code | 2026-04-05
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05
 - [ ] Category distribution report by date + chart (issue #134, feat/issue-134-category-distribution-by-date) | @claude-code | 2026-04-05
+- [ ] DJ Show Player component (issue #21, feat/issue-21-dj-show-player) | @claude-code | 2026-04-05
+- [ ] Spotify/Apple Music widgets (issue #22, feat/issue-22-music-widgets) | @claude-code | 2026-04-05
+- [ ] Visual show timeline + audio export (issue #23, feat/issue-23-show-timeline) | @claude-code | 2026-04-05
 
 ## Recently Completed
+- [x] Script template management UI (issue #20, feat/issue-20-script-template-ui) | @claude-code | 2026-04-05
 - [x] Deploy DJ service on Railway — set env vars + CD deploy (issue #100, fix/issue-100-dj-deploy) | @claude-code | 2026-04-05
 - [x] L2 knowledge base — Qdrant + FastAPI (issue #34, feat/issue-34-l2-knowledge-base) | @claude-code | 2026-04-05
 - [x] Implement GET /api/v1/dashboard/stats endpoint (issue #101, feat/dashboard-stats) | @claude-code | 2026-04-05


### PR DESCRIPTION
## Summary
- Script template management page at `/dj/templates` with full CRUD (list, create, edit inline, delete with confirmation)
- Adds `created_at` column to templates table for audit visibility
- Adds segment type count badges above table showing inventory at a glance (e.g. `show_intro x2`)
- Each template row shows: segment type badge, name, prompt preview (truncated), created date, active/inactive status, edit/delete actions
- Station selector auto-selects first accessible station

## Test plan
- [ ] Navigate to /dj/templates — verify station selector and template list load
- [ ] Create a new template — verify it appears in the list
- [ ] Edit an existing template inline — verify changes persist
- [ ] Delete a template — verify confirmation dialog appears and template is removed
- [ ] Verify created_at column shows formatted date
- [ ] Verify segment count badges reflect correct counts per type

🤖 Generated with [Claude Code](https://claude.com/claude-code)