### PR TITLE
feat(dj): DJ Show Player with volume control (issue #21)

### DIFF
--- a/frontend/src/components/DjPlayer.tsx
+++ b/frontend/src/components/DjPlayer.tsx
@@ -14,7 +14,7 @@ const SEGMENT_TYPE_LABELS: Record<string, string> = {
 };
 
 export default function DjPlayer() {
-  const { currentSegment, isPlaying, progress, queue, pause, resume, skipNext, stop } = useDjPlayer();
+  const { currentSegment, isPlaying, progress, volume, queue, pause, resume, skipNext, stop, setVolume } = useDjPlayer();
 
   if (!currentSegment) return null;
 
@@ -83,6 +83,29 @@ export default function DjPlayer() {
               </svg>
             </button>
           )}
+
+          {/* Volume */}
+          <div className="hidden sm:flex items-center gap-1.5 ml-1">
+            <svg className="w-3.5 h-3.5 text-gray-500 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+              {volume === 0 ? (
+                <path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/>
+              ) : volume < 0.5 ? (
+                <path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/>
+              ) : (
+                <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
+              )}
+            </svg>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={volume}
+              onChange={(e) => setVolume(parseFloat(e.target.value))}
+              className="w-16 accent-violet-500 cursor-pointer"
+              aria-label="Volume"
+            />
+          </div>
 
           {/* Stop / close */}
           <button

--- a/frontend/src/lib/DjPlayerContext.tsx
+++ b/frontend/src/lib/DjPlayerContext.tsx
@@ -15,6 +15,7 @@ interface DjPlayerState {
   currentSegment: DjPlayerSegment | null;
   isPlaying: boolean;
   progress: number; // 0–1
+  volume: number; // 0–1
   queue: DjPlayerSegment[];
   playSegment: (seg: DjPlayerSegment) => void;
   playQueue: (segments: DjPlayerSegment[]) => void;
@@ -22,6 +23,7 @@ interface DjPlayerState {
   resume: () => void;
   skipNext: () => void;
   stop: () => void;
+  setVolume: (v: number) => void;
 }
 
 const DjPlayerContext = createContext<DjPlayerState | null>(null);
@@ -30,10 +32,12 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
   const [currentSegment, setCurrentSegment] = useState<DjPlayerSegment | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [volume, setVolumeState] = useState(1);
   const [queue, setQueue] = useState<DjPlayerSegment[]>([]);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const queueRef = useRef<DjPlayerSegment[]>([]);
+  const volumeRef = useRef(1);
 
   const stopCurrent = useCallback(() => {
     if (audioRef.current) {
@@ -45,6 +49,13 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
     }
     setProgress(0);
     setIsPlaying(false);
+  }, []);
+
+  const setVolume = useCallback((v: number) => {
+    const clamped = Math.max(0, Math.min(1, v));
+    volumeRef.current = clamped;
+    setVolumeState(clamped);
+    if (audioRef.current) audioRef.current.volume = clamped;
   }, []);
 
   const playNext = useCallback(() => {
@@ -61,6 +72,7 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
     setQueue([...rest]);
 
     const audio = new Audio(next.audioUrl);
+    audio.volume = volumeRef.current;
     audioRef.current = audio;
     setCurrentSegment(next);
     setIsPlaying(true);
@@ -82,6 +94,7 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
     setQueue([]);
 
     const audio = new Audio(seg.audioUrl);
+    audio.volume = volumeRef.current;
     audioRef.current = audio;
     setCurrentSegment(seg);
     setIsPlaying(true);
@@ -110,6 +123,7 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
     setQueue([...rest]);
 
     const audio = new Audio(first.audioUrl);
+    audio.volume = volumeRef.current;
     audioRef.current = audio;
     setCurrentSegment(first);
     setIsPlaying(true);
@@ -156,6 +170,7 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
       currentSegment,
       isPlaying,
       progress,
+      volume,
       queue,
       playSegment,
       playQueue,
@@ -163,6 +178,7 @@ export function DjPlayerProvider({ children }: { children: React.ReactNode }) {
       resume,
       skipNext,
       stop,
+      setVolume,
     }}>
       {children}
     </DjPlayerContext.Provider>


### PR DESCRIPTION
## Summary
- `DjPlayer` fixed-bottom bar already existed with play/pause, segment title, progress bar, and queue count
- Adds volume slider control with adaptive icon (mute/low/high) to the player bar
- Adds `volume` state and `setVolume` action to `DjPlayerContext`, wired to `Audio.volume` on all playback paths
- Volume control is hidden on mobile (shown on sm+ screens) to keep the bar compact
- Player is already integrated into root layout via `ClientLayout`

## Test plan
- [ ] Open a playlist with a DJ script, click "Preview Show" — DJ player bar appears at bottom
- [ ] Verify play/pause, skip, and stop controls work
- [ ] Adjust volume slider — verify audio level changes
- [ ] Verify mute icon shows when volume is 0, low icon for <50%, high icon for ≥50%
- [ ] On mobile width — verify volume control is hidden but other controls work

🤖 Generated with [Claude Code](https://claude.com/claude-code)