### PR TITLE
feat(tools): add L2 knowledge base — Qdrant + FastAPI semantic memory (#34)

### DIFF
--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -12,13 +12,12 @@ Before starting any task, an agent MUST:
 
 ## Active Work
 - [ ] Fix high vulnerabilities (Next.js upgrade, Fastify upgrade, tar override) | @gemini-cli | 2026-04-04
+- [ ] Re-generate single playlist slot (issue #132, feat/issue-132-slot-regen) | @claude-code | 2026-04-05
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05
+- [ ] Category distribution report by date + chart (issue #134, feat/issue-134-category-distribution-by-date) | @claude-code | 2026-04-05
 
 ## Recently Completed
-- [x] Auto-approve script review toggle (issue #33, PR #135) | @claude-code | 2026-04-05
-- [x] Category distribution by date + bar chart (issue #134, PR #143) | @claude-code | 2026-04-05
-- [x] Day-of-week template overrides (issue #130, PR #138) | @claude-code | 2026-04-05
-- [x] Re-generate single slot (issue #132, PR #140) | @claude-code | 2026-04-05
+- [x] L2 knowledge base — Qdrant + FastAPI (issue #34, feat/issue-34-l2-knowledge-base) | @claude-code | 2026-04-05
 - [x] Implement GET /api/v1/dashboard/stats endpoint (issue #101, feat/dashboard-stats) | @claude-code | 2026-04-05
 - [x] Add DJ link to sidebar navigation (issue #103, feat/dj-sidebar-nav) | @claude-code | 2026-04-04
 - [x] DJ Personality Feature (persona_config JSONB, PersonaConfig type, prompt builder, seed, frontend form) | @claude-code | 2026-04-04


### PR DESCRIPTION
## Summary

- Adds `tools/knowledge-base/` — a standalone Python service that gives agents a persistent, searchable memory store backed by [Qdrant](https://qdrant.tech/) vector DB
- `KnowledgeBaseClient.push()` upserts a vector + payload; `search()` returns nearest neighbours — both using `all-MiniLM-L6-v2` embeddings via sentence-transformers
- FastAPI app exposes `POST /embed` and `POST /search` over HTTP (port 8000)
- `docker-compose.yml` spins up `qdrant:v1.9.4` + `kb-api` with a named volume for persistence
- `seed.py` pre-loads 3 real PlayGen bugs so the collection isn't cold on first use
- `.env.example` updated with `QDRANT_URL` and `KB_API_URL`

## No existing service touched

This is a fully standalone Python service. Zero changes to Node microservices, frontend, gateway, or DB migrations.

## Test plan

- [ ] `cd tools/knowledge-base && docker compose up --build -d` starts both containers
- [ ] `GET http://localhost:8000/health` returns `{"status":"ok"}`
- [ ] `docker compose exec kb-api python seed.py` seeds 3 entries without error
- [ ] `POST /search {"query":"fastify plugin startup crash","top_k":3}` returns the rate-limit seed entry as top hit
- [ ] `POST /embed` with a new entry returns a UUID point ID
- [ ] Qdrant UI at `http://localhost:6333/dashboard` shows `agent_insights` collection with 3+ points

🤖 Generated with [Claude Code](https://claude.com/claude-code)