### PR TITLE
feat(library): Spotify/Apple Music embed widgets (issue #22)

### DIFF
--- a/frontend/src/app/playlists/[id]/page.tsx
+++ b/frontend/src/app/playlists/[id]/page.tsx
@@ -7,6 +7,7 @@ import { getCurrentUser } from '@/lib/auth';
 import { api } from '@/lib/api';
 import type { ApiError } from '@/lib/api';
 import { useDjPlayer } from '@/lib/DjPlayerContext';
+import MusicWidget from '@/components/MusicWidget';
 
 type PlaylistStatus = 'draft' | 'generating' | 'ready' | 'approved' | 'exported' | 'failed';
 type DjReviewStatus = 'pending_review' | 'approved' | 'rejected' | 'auto_approved';
@@ -53,6 +54,8 @@ interface PlaylistEntry {
   song_artist: string;
   category_label: string;
   is_manual_override: boolean;
+  spotify_id?: string | null;
+  apple_music_id?: string | null;
 }
 
 interface PlaylistWithEntries extends Playlist {
@@ -113,6 +116,7 @@ export default function PlaylistDetailPage() {
   const [editText, setEditText] = useState('');
   const [regenLoading, setRegenLoading] = useState<Record<string, boolean>>({});
   const [regenError, setRegenError] = useState<Record<string, string>>({});
+  const [musicWidgetEntryId, setMusicWidgetEntryId] = useState<string | null>(null);
 
   const djPlayer = useDjPlayer();
 
@@ -804,45 +808,80 @@ export default function PlaylistDetailPage() {
                 const hourEntries = (byHour.get(hour) ?? []).sort((a, b) => a.position - b.position);
                 return (
                   <Fragment key={hour}>
-                    {hourEntries.map((entry, idx) => (
-                      <tr
-                        key={entry.id}
-                        className={`border-b border-[#2a2a40] hover:bg-[#24243a] ${entry.is_manual_override ? 'bg-yellow-900/10' : ''}`}
-                      >
-                        {idx === 0 ? (
-                          <td
-                            rowSpan={hourEntries.length}
-                            className="px-4 py-3 font-medium text-gray-400 align-top border-r border-[#2a2a40] whitespace-nowrap"
+                    {hourEntries.map((entry, idx) => {
+                      const hasMusicWidget = !!(entry.spotify_id || entry.apple_music_id);
+                      const isWidgetOpen = musicWidgetEntryId === entry.id;
+                      return (
+                        <Fragment key={entry.id}>
+                          <tr
+                            className={`border-b border-[#2a2a40] hover:bg-[#24243a] ${entry.is_manual_override ? 'bg-yellow-900/10' : ''}`}
                           >
-                            {hour}:00
-                          </td>
-                        ) : null}
-                        <td className="px-4 py-3 text-gray-500">{entry.position}</td>
-                        <td className="px-4 py-3 text-gray-400">{entry.category_label}</td>
-                        <td className="px-4 py-3 font-medium text-white">{entry.song_title}</td>
-                        <td className="px-4 py-3 text-gray-400">{entry.song_artist}</td>
-                        <td className="px-4 py-3">
-                          {entry.is_manual_override && (
-                            <span className="badge bg-yellow-900/30 text-yellow-400">Override</span>
+                            {idx === 0 ? (
+                              <td
+                                rowSpan={hourEntries.length}
+                                className="px-4 py-3 font-medium text-gray-400 align-top border-r border-[#2a2a40] whitespace-nowrap"
+                              >
+                                {hour}:00
+                              </td>
+                            ) : null}
+                            <td className="px-4 py-3 text-gray-500">{entry.position}</td>
+                            <td className="px-4 py-3 text-gray-400">{entry.category_label}</td>
+                            <td className="px-4 py-3 font-medium text-white">
+                              <div className="flex items-center gap-1.5">
+                                {entry.song_title}
+                                {hasMusicWidget && (
+                                  <button
+                                    onClick={() => setMusicWidgetEntryId(isWidgetOpen ? null : entry.id)}
+                                    title={isWidgetOpen ? 'Hide music preview' : 'Show music preview'}
+                                    className={`flex-shrink-0 w-5 h-5 flex items-center justify-center rounded transition-colors ${
+                                      isWidgetOpen
+                                        ? 'text-green-400 bg-green-900/20'
+                                        : 'text-gray-600 hover:text-green-400'
+                                    }`}
+                                  >
+                                    <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+                                      <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
+                                    </svg>
+                                  </button>
+                                )}
+                              </div>
+                            </td>
+                            <td className="px-4 py-3 text-gray-400">{entry.song_artist}</td>
+                            <td className="px-4 py-3">
+                              {entry.is_manual_override && (
+                                <span className="badge bg-yellow-900/30 text-yellow-400">Override</span>
+                              )}
+                            </td>
+                            <td className="px-4 py-3">
+                              {playlist?.status !== 'approved' && playlist?.status !== 'exported' && (
+                                <button
+                                  onClick={() => {
+                                    setOverrideEntry(entry);
+                                    setSearchQuery('');
+                                    setSearchResults([]);
+                                    setOverrideError(null);
+                                  }}
+                                  className="text-xs text-violet-400 hover:text-violet-300 font-medium"
+                                >
+                                  Override
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                          {/* Music widget expansion row */}
+                          {isWidgetOpen && hasMusicWidget && (
+                            <tr className="border-b border-[#2a2a40] bg-[#0f0f1a]">
+                              <td colSpan={7} className="px-4 py-3">
+                                <MusicWidget
+                                  spotifyId={entry.spotify_id}
+                                  appleMusicId={entry.apple_music_id}
+                                />
+                              </td>
+                            </tr>
                           )}
-                        </td>
-                        <td className="px-4 py-3">
-                          {playlist?.status !== 'approved' && playlist?.status !== 'exported' && (
-                            <button
-                              onClick={() => {
-                                setOverrideEntry(entry);
-                                setSearchQuery('');
-                                setSearchResults([]);
-                                setOverrideError(null);
-                              }}
-                              className="text-xs text-violet-400 hover:text-violet-300 font-medium"
-                            >
-                              Override
-                            </button>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
+                        </Fragment>
+                      );
+                    })}
                   </Fragment>
                 );
               })

--- a/frontend/src/components/MusicWidget.tsx
+++ b/frontend/src/components/MusicWidget.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+
+interface MusicWidgetProps {
+  /** Spotify track ID (the part after /track/ in the Spotify URL) */
+  spotifyId?: string | null;
+  /** Apple Music track/album ID */
+  appleMusicId?: string | null;
+}
+
+/**
+ * Embeds a Spotify or Apple Music preview widget for a song.
+ * Only renders when at least one platform ID is provided.
+ */
+export default function MusicWidget({ spotifyId, appleMusicId }: MusicWidgetProps) {
+  const [platform, setPlatform] = useState<'spotify' | 'apple'>(
+    spotifyId ? 'spotify' : 'apple',
+  );
+
+  if (!spotifyId && !appleMusicId) return null;
+
+  const hasBoth = Boolean(spotifyId && appleMusicId);
+
+  return (
+    <div className="mt-2 rounded-xl overflow-hidden bg-black/20 border border-[#2a2a40]">
+      {/* Platform toggle — only shown when both IDs are available */}
+      {hasBoth && (
+        <div className="flex border-b border-[#2a2a40]">
+          <button
+            onClick={(e) => { e.stopPropagation(); setPlatform('spotify'); }}
+            className={`flex-1 py-1.5 text-[10px] font-semibold uppercase tracking-wider transition-colors flex items-center justify-center gap-1 ${
+              platform === 'spotify'
+                ? 'text-green-400 bg-green-900/10'
+                : 'text-gray-600 hover:text-gray-400'
+            }`}
+          >
+            <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.516 17.285c-.213.349-.667.454-1.016.242-2.785-1.703-6.29-2.088-10.418-1.144-.397.091-.795-.158-.886-.555-.091-.397.158-.795.555-.886 4.516-1.032 8.386-.588 11.521 1.327.349.213.454.667.244 1.016zm1.471-3.27c-.269.437-.843.573-1.279.304-3.188-1.96-8.048-2.529-11.82-1.383-.489.148-1.006-.13-1.154-.618-.148-.489.13-1.006.618-1.154 4.309-1.308 9.672-.674 13.331 1.572.437.269.573.843.304 1.279zm.127-3.404c-3.824-2.27-10.131-2.48-13.784-1.373-.587.178-1.207-.154-1.385-.741-.178-.587.154-1.207.741-1.385 4.195-1.272 11.169-1.027 15.574 1.587.528.314.704 1 .39 1.527-.313.528-1 .704-1.536.385z"/>
+            </svg>
+            Spotify
+          </button>
+          <span className="w-px bg-[#2a2a40]" />
+          <button
+            onClick={(e) => { e.stopPropagation(); setPlatform('apple'); }}
+            className={`flex-1 py-1.5 text-[10px] font-semibold uppercase tracking-wider transition-colors flex items-center justify-center gap-1 ${
+              platform === 'apple'
+                ? 'text-red-400 bg-red-900/10'
+                : 'text-gray-600 hover:text-gray-400'
+            }`}
+          >
+            <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+            </svg>
+            Apple Music
+          </button>
+        </div>
+      )}
+
+      {/* Spotify embed */}
+      {(platform === 'spotify' || !hasBoth) && spotifyId && (
+        <iframe
+          src={`https://open.spotify.com/embed/track/${spotifyId}?utm_source=generator&theme=0`}
+          width="100%"
+          height="80"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy"
+          title="Spotify preview"
+          className="block"
+          style={{ border: 0 }}
+        />
+      )}
+
+      {/* Apple Music embed */}
+      {(platform === 'apple' || !hasBoth) && appleMusicId && (
+        <iframe
+          allow="autoplay *; encrypted-media *; fullscreen *; clipboard-write"
+          height="150"
+          style={{ width: '100%', maxWidth: '660px', overflow: 'hidden', border: 0 }}
+          sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-storage-access-by-user-activation allow-top-navigation-by-user-activation"
+          src={`https://embed.music.apple.com/us/album/${appleMusicId}?app=music`}
+          title="Apple Music preview"
+          className="block"
+          loading="lazy"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New \`MusicWidget\` component at \`frontend/src/components/MusicWidget.tsx\`
- Embeds Spotify track iframe (height 80px compact player) when \`spotify_id\` is present on a song
- Embeds Apple Music album iframe (height 150px) when \`apple_music_id\` is present
- Toggles between platforms with branded buttons when both IDs exist
- Fully optional — component returns null if neither ID is provided
- Integrated into playlist detail page song rows: a music note icon appears in the title cell when IDs exist; clicking expands a full-width widget row below the song

## Test plan
- [ ] Songs without spotify_id or apple_music_id — no music icon shown
- [ ] Song with spotify_id only — clicking icon shows Spotify embed
- [ ] Song with apple_music_id only — clicking icon shows Apple Music embed  
- [ ] Song with both IDs — platform toggle buttons shown, switches between embeds
- [ ] Clicking the icon again collapses the widget
- [ ] Widget does not affect table layout for other rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)