### PR TITLE
feat(monitoring): deployment monitor agent — Vercel + Railway crash detection (#166)

### DIFF
--- a/gateway/nginx.conf.template
+++ b/gateway/nginx.conf.template
@@ -195,6 +195,43 @@ server {
         add_header Content-Type application/json;
     }
 
+    # ─── Per-service health proxies (for deployment monitoring) ───
+    location /health/auth {
+        set $svc http://${AUTH_HOST}:3001;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/station {
+        set $svc http://${STATION_HOST}:3002;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/library {
+        set $svc http://${LIBRARY_HOST}:3003;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/scheduler {
+        set $svc http://${SCHEDULER_HOST}:3004;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/playlist {
+        set $svc http://${PLAYLIST_HOST}:3005;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/analytics {
+        set $svc http://${ANALYTICS_HOST}:3006;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+    location /health/dj {
+        set $svc http://${DJ_HOST}:3007;
+        proxy_pass $svc/health;
+        proxy_set_header Host $host;
+    }
+
     # ─── Frontend catch-all ───────────────────────────────────────
     # Active when FRONTEND_HOST is set (local Docker Compose).
     # On Railway/Vercel the frontend is on Vercel — leave FRONTEND_HOST blank.

--- a/scripts/deployment-monitor.sh
+++ b/scripts/deployment-monitor.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Deployment Monitor — checks Vercel + Railway service health and alerts via Telegram.
+#
+# Required env vars:
+#   GATEWAY_URL          — public gateway base URL (e.g. https://api.playgen.site)
+#   TELEGRAM_BOT_TOKEN   — Telegram bot token
+#   TELEGRAM_CHAT_ID     — Telegram chat/group ID
+#
+# Optional env vars:
+#   FRONTEND_URL         — Vercel frontend URL (e.g. https://www.playgen.site)
+#   VERCEL_TOKEN         — Vercel API token
+#   VERCEL_PROJECT_ID    — Vercel project ID (from vercel project inspect)
+#   RAILWAY_TOKEN        — Railway API token (for richer deployment info)
+#   ALERT_THRESHOLD      — failures before alerting (default: 1)
+
+set -euo pipefail
+
+GATEWAY_URL="${GATEWAY_URL:?GATEWAY_URL must be set}"
+TG_TOKEN="${TELEGRAM_BOT_TOKEN:?TELEGRAM_BOT_TOKEN must be set}"
+TG_CHAT="${TELEGRAM_CHAT_ID:?TELEGRAM_CHAT_ID must be set}"
+FRONTEND_URL="${FRONTEND_URL:-}"
+VERCEL_TOKEN="${VERCEL_TOKEN:-}"
+VERCEL_PROJECT_ID="${VERCEL_PROJECT_ID:-}"
+RAILWAY_TOKEN="${RAILWAY_TOKEN:-}"
+TIMEOUT=10
+
+FAILED=0
+PASSED=0
+ALERTS=()
+RESULTS=()
+
+tg_send() {
+  local msg="$1"
+  curl -s -X POST "https://api.telegram.org/bot${TG_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "{\"chat_id\":\"${TG_CHAT}\",\"text\":\"${msg}\"}" > /dev/null 2>&1 || true
+}
+
+check_url() {
+  local name="$1"
+  local url="$2"
+  local expected="${3:-200}"
+  local status
+  status=$(curl -sf -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$url" 2>/dev/null || echo "000")
+  if [ "$status" = "$expected" ]; then
+    RESULTS+=("[PASS] $name -> $status")
+    PASSED=$((PASSED + 1))
+  else
+    RESULTS+=("[FAIL] $name -> $status (expected $expected)")
+    ALERTS+=("$name: HTTP $status")
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo "=== Deployment Monitor — $(date '+%Y-%m-%d %H:%M:%S %Z') ==="
+echo ""
+
+# ── 1. Gateway health ──────────────────────────────────────────────────────────
+echo "--- Gateway ---"
+check_url "gateway" "${GATEWAY_URL}/health"
+
+# ── 2. Per-service health via gateway proxy ────────────────────────────────────
+echo "--- Services ---"
+for svc in auth station library scheduler playlist analytics dj; do
+  check_url "$svc" "${GATEWAY_URL}/health/${svc}"
+done
+
+# ── 3. Frontend health ─────────────────────────────────────────────────────────
+if [ -n "$FRONTEND_URL" ]; then
+  echo "--- Frontend ---"
+  check_url "frontend" "$FRONTEND_URL" "200"
+fi
+
+# ── 4. Vercel latest deployment status ────────────────────────────────────────
+if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+  echo "--- Vercel ---"
+  DEPLOY_JSON=$(curl -sf \
+    -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+    "https://api.vercel.com/v9/projects/${VERCEL_PROJECT_ID}/deployments?limit=1&target=production" \
+    --max-time 15 2>/dev/null || echo "{}")
+  DEPLOY_STATE=$(echo "$DEPLOY_JSON" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin).get('deployments',[{}])[0]; print(d.get('state','unknown'))" \
+    2>/dev/null || echo "unknown")
+  DEPLOY_URL=$(echo "$DEPLOY_JSON" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin).get('deployments',[{}])[0]; print(d.get('url',''))" \
+    2>/dev/null || echo "")
+  if [ "$DEPLOY_STATE" = "READY" ]; then
+    RESULTS+=("[PASS] vercel deployment -> READY ($DEPLOY_URL)")
+    PASSED=$((PASSED + 1))
+  elif [ "$DEPLOY_STATE" = "unknown" ]; then
+    RESULTS+=("[WARN] vercel deployment -> could not fetch status")
+  else
+    RESULTS+=("[FAIL] vercel deployment -> $DEPLOY_STATE ($DEPLOY_URL)")
+    ALERTS+=("Vercel deployment: $DEPLOY_STATE")
+    FAILED=$((FAILED + 1))
+  fi
+fi
+
+# ── 5. Print results ───────────────────────────────────────────────────────────
+echo ""
+for line in "${RESULTS[@]}"; do
+  echo "$line"
+done
+echo ""
+echo "Summary: ${PASSED} passed, ${FAILED} failed"
+
+# ── 6. Telegram alert on any failure ──────────────────────────────────────────
+if [ "$FAILED" -gt 0 ]; then
+  ALERT_BODY=$(printf '%s\n' "${ALERTS[@]}")
+  MSG="🚨 DEPLOYMENT ALERT — $(date '+%Y-%m-%d %H:%M')
+${ALERT_BODY}
+Passed: ${PASSED} | Failed: ${FAILED}
+Check: ${GATEWAY_URL}/health"
+  echo ""
+  echo "Sending Telegram alert..."
+  tg_send "$MSG"
+  echo "Alert sent."
+  exit 1
+fi
+
+echo "All checks passed."
+exit 0

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2,51 +2,43 @@
 set -euo pipefail
 
 GATEWAY_URL="${GATEWAY_URL:?GATEWAY_URL must be set}"
-FRONTEND_URL="${FRONTEND_URL:?FRONTEND_URL must be set}"
+FRONTEND_URL="${FRONTEND_URL:-}"
 
 FAILED=0
 
-echo "=== Gateway Health Check ==="
-STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "${GATEWAY_URL}/health" 2>/dev/null || echo "000")
-if [ "$STATUS" = "200" ]; then
-  echo "[PASS] gateway -> $STATUS"
-else
-  echo "[FAIL] gateway -> $STATUS"
-  FAILED=1
-fi
-
-echo ""
-echo "=== Service Health Checks (via gateway) ==="
-# Each service registers GET /health returning { status: 'ok' }
-# Gateway proxies /api/v1/dj/* to dj service; other services have their own /health at root
-for svc in auth station library scheduler playlist analytics; do
-  # Services expose /health directly; gateway does not proxy these by default
-  # Use the gateway health endpoint as a proxy indicator
-  URL="${GATEWAY_URL}/health"
-  STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/dev/null || echo "000")
-  if [ "$STATUS" = "200" ]; then
-    echo "[PASS] $svc (via gateway) -> $STATUS"
+check() {
+  local name="$1"
+  local url="$2"
+  local status
+  status=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
+  if [ "$status" = "200" ]; then
+    echo "[PASS] $name -> $status"
   else
-    echo "[FAIL] $svc (via gateway) -> $STATUS"
+    echo "[FAIL] $name -> $status"
     FAILED=1
   fi
-done
+}
+
+echo "=== Gateway Health ==="
+check "gateway" "${GATEWAY_URL}/health"
 
 echo ""
-echo "=== Frontend Health Check ==="
-STATUS=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$FRONTEND_URL" 2>/dev/null || echo "000")
-if [ "$STATUS" = "200" ]; then
-  echo "[PASS] frontend -> $STATUS"
-else
-  echo "[FAIL] frontend -> $STATUS"
-  FAILED=1
+echo "=== Per-Service Health (via gateway proxy) ==="
+for svc in auth station library scheduler playlist analytics dj; do
+  check "$svc" "${GATEWAY_URL}/health/${svc}"
+done
+
+if [ -n "$FRONTEND_URL" ]; then
+  echo ""
+  echo "=== Frontend Health ==="
+  check "frontend" "$FRONTEND_URL"
 fi
 
 echo ""
 if [ "$FAILED" -eq 0 ]; then
   echo "All smoke tests passed."
 else
-  echo "Some smoke tests failed!"
+  echo "Some smoke tests FAILED."
 fi
 
 exit $FAILED

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -11,6 +11,7 @@ Before starting any task, an agent MUST:
 7. PR MERGE MANDATE: Before merging any PR, verify `mergeable_state` is clean. Rebase onto `origin/main` locally, resolve conflicts manually (never blindly `-X theirs`), verify `pnpm run typecheck` passes, then force-push and wait for CI to go green before merging.
 
 ## Active Work
+- [ ] Deployment monitoring agent — Vercel + Railway error alerting (issue #166, feat/issue-166-deployment-monitor) | @claude-code | 2026-04-05
 - [ ] Fix high vulnerabilities (Next.js upgrade, Fastify upgrade, tar override) | @gemini-cli | 2026-04-04
 - [ ] Re-generate single playlist slot (issue #132, feat/issue-132-slot-regen) | @claude-code | 2026-04-05
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05

--- a/tools/agent-ops/daemon/daemon.py
+++ b/tools/agent-ops/daemon/daemon.py
@@ -366,6 +366,31 @@ def prompt_health() -> str:
     )
 
 
+def prompt_monitor() -> str:
+    deploy    = DEPLOY
+    gateway   = deploy.get("gateway_url_env", "GATEWAY_URL")
+    frontend  = deploy.get("frontend_url_env", "FRONTEND_URL")
+    monitor_script = TECH.get("monitor_script", "bash scripts/deployment-monitor.sh")
+    return (
+        f"You are the deployment monitor for {PROJECT_NAME} at {WORKDIR}. "
+        f"export PATH=/opt/homebrew/bin:$PATH. "
+        f"Run the deployment monitor and investigate any failures:\n"
+        f"1. {monitor_script} 2>&1\n"
+        f"2. If any service failed: check recent CI runs — "
+        f"   gh run list --limit 10 --json status,conclusion,headBranch,createdAt | jq .\n"
+        f"3. For each failed service, check its Railway logs if RAILWAY_TOKEN is set:\n"
+        f"   Look at the last deployment logs for crash signatures.\n"
+        f"4. If a crash is identified and fixable (config error, missing env var, OOM): "
+        f"   open a GitHub issue labelled 'bug P0' with title 'CRASH: <service> - <reason>' "
+        f"   and assign it to the bug worker queue.\n"
+        f"5. Send a Telegram summary (under 500 chars):\n"
+        f"   curl -s -X POST 'https://api.telegram.org/bot{TG_TOKEN}/sendMessage' \\\n"
+        f"   -H 'Content-Type: application/json' \\\n"
+        f"   -d '{{\"chat_id\":\"{TG_CHAT}\",\"text\":\"MONITOR: X/Y services healthy | issues found | actions taken\"}}'\n"
+        f"Do NOT push any code — only investigate, report, and open issues."
+    )
+
+
 def build_prompt(slot_id: str, slot_type: str, slot_index: int,
                  bugs, feats, feature_prs, dep_prs):
     """Dispatch to the right prompt builder based on slot type."""
@@ -379,6 +404,8 @@ def build_prompt(slot_id: str, slot_type: str, slot_index: int,
         return prompt_merge(feature_prs, dep_prs)
     elif slot_type == "health":
         return prompt_health()
+    elif slot_type == "monitor":
+        return prompt_monitor()
     else:
         # Custom slot type: build a generic prompt
         return (
@@ -426,6 +453,7 @@ def manage_pool():
             "ticket-feat": bool(feats),
             "merge":       bool(feature_prs or dep_prs),
             "health":      True,
+            "monitor":     True,
         }.get(slot_type, True)  # unknown types always have work
 
         # ticket-bug-1 only when bugs actually exist

--- a/tools/agent-ops/project.config.example.json
+++ b/tools/agent-ops/project.config.example.json
@@ -45,6 +45,11 @@
       "type": "health",
       "always": true,
       "desc": "Health check"
+    },
+    "monitor-0": {
+      "type": "monitor",
+      "always": true,
+      "desc": "Deployment monitor (Vercel + Railway crash detection)"
     }
   },
   "reset_hours": [0, 5, 9, 14, 19],
@@ -56,6 +61,7 @@
     "lint_command": "pnpm run lint",
     "typecheck_command": "pnpm run typecheck",
     "health_script": "bash scripts/project-health.sh",
+    "monitor_script": "bash scripts/deployment-monitor.sh",
     "collab_file": "tasks/agent-collab.md",
     "docker_services": []
   },


### PR DESCRIPTION
## Summary

- **`scripts/deployment-monitor.sh`** — new script: checks gateway + all 7 backend services via individual health endpoints, checks Vercel deployment state via API, sends Telegram alert on any failure
- **nginx per-service health routes** — adds `/health/auth`, `/health/station`, etc. proxy routes so each Railway service can be checked through the public gateway
- **`scripts/smoke-test.sh` fix** — was broken (used gateway `/health` for all services); now uses per-service proxy routes
- **`daemon.py` monitor slot type** — `prompt_monitor()` runs a `monitor-0` agent at each reset window to investigate failures and file P0 GitHub issues on crashes

## How it works

Each daemon reset window, `monitor-0` runs `deployment-monitor.sh` which:
1. Checks `GATEWAY_URL/health` (gateway)
2. Checks `GATEWAY_URL/health/<svc>` for all 7 services (new nginx routes)
3. Checks Vercel latest production deployment state via API
4. Sends Telegram alert with failure list + opens P0 issue if crash detected

## Environment variables needed

| Var | Required | Purpose |
|-----|----------|---------|
| `GATEWAY_URL` | yes | `https://api.playgen.site` |
| `FRONTEND_URL` | optional | `https://www.playgen.site` |
| `VERCEL_TOKEN` | optional | Vercel deployment state check |
| `VERCEL_PROJECT_ID` | optional | Vercel project identifier |

## Test plan

- [ ] `GATEWAY_URL=https://api.playgen.site bash scripts/deployment-monitor.sh` passes when services healthy
- [ ] Telegram alert fires when a service is down
- [ ] `bash scripts/smoke-test.sh` fails individually per service (not masked by gateway)
- [ ] CI typecheck passes

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)