### PR TITLE
feat(analytics): category distribution report by date with chart (#134)

### DIFF
--- a/services/analytics/package.json
+++ b/services/analytics/package.json
@@ -6,8 +6,9 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
-    "test": "vitest run",
-    "test:unit": "vitest run"
+    "test": "vitest run src",
+    "test:unit": "vitest run src",
+    "test:integration": "vitest run tests/integration"
   },
   "dependencies": {
     "@playgen/middleware": "workspace:*",

--- a/services/analytics/src/services/analyticsService.test.ts
+++ b/services/analytics/src/services/analyticsService.test.ts
@@ -4,6 +4,7 @@ import {
   getOverplayedSongs,
   getUnderplayedSongs,
   getCategoryDistribution,
+  getCategoryDistributionByDate,
   getSongHistory,
 } from './analyticsService';
 
@@ -169,6 +170,72 @@ describe('getCategoryDistribution', () => {
     const result = await getCategoryDistribution('station-1', 7);
 
     expect(result).toEqual([]);
+  });
+});
+
+describe('getCategoryDistributionByDate', () => {
+  it('returns category distribution with percentage as a number for a specific date', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { category_code: 'POP', category_label: 'Pop Music', total_plays: 48, percentage: '75.00' },
+        { category_code: 'RNB', category_label: 'R&B', total_plays: 16, percentage: '25.00' },
+      ],
+    });
+
+    const result = await getCategoryDistributionByDate('station-1', '2026-04-05');
+
+    expect(result).toHaveLength(2);
+
+    expect(result[0].category_code).toBe('POP');
+    expect(result[0].category_label).toBe('Pop Music');
+    expect(result[0].total_plays).toBe(48);
+    expect(typeof result[0].percentage).toBe('number');
+    expect(result[0].percentage).toBe(75);
+
+    expect(result[1].category_code).toBe('RNB');
+    expect(typeof result[1].percentage).toBe('number');
+    expect(result[1].percentage).toBe(25);
+  });
+
+  it('returns an empty array when no playlist is scheduled for the date', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getCategoryDistributionByDate('station-1', '2026-01-01');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns zero percentage when grand total is 0', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { category_code: 'POP', category_label: 'Pop Music', total_plays: 0, percentage: '0.00' },
+      ],
+    });
+
+    const result = await getCategoryDistributionByDate('station-1', '2026-04-05');
+
+    expect(result[0].percentage).toBe(0);
+  });
+
+  it('queries with the correct stationId and date parameters', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await getCategoryDistributionByDate('station-abc', '2026-03-15');
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('pl.station_id = $1'),
+      ['station-abc', '2026-03-15'],
+    );
+  });
+
+  it('uses playlist_entries (not play_history) for the count', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await getCategoryDistributionByDate('station-1', '2026-04-05');
+
+    const [sql] = mockQuery.mock.calls[0] as [string, string[]];
+    expect(sql).toContain('playlist_entries');
+    expect(sql).not.toContain('play_history');
   });
 });
 

--- a/services/analytics/tests/integration/categoryDistribution.test.ts
+++ b/services/analytics/tests/integration/categoryDistribution.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Integration tests — GET /api/v1/stations/:id/analytics/category-distribution
+ *
+ * Covers:
+ *  - Auth: 401 without token
+ *  - Validation: 400 on invalid date format
+ *  - Happy path: returns category breakdown for a scheduled date
+ *  - Tenant isolation: 403 when user does not have access to the station
+ *  - Empty result: no playlist on that date → empty array
+ *
+ * Runs against a real PostgreSQL database; automatically skipped when
+ * TEST_DATABASE_URL is not set.
+ *
+ * To run locally:
+ *   TEST_DATABASE_URL=postgres://playgen:changeme@localhost:5432/playgen_test \
+ *     pnpm --filter @playgen/analytics-service test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+// Apply TEST_DATABASE_URL env vars before any service code is imported so
+// the module-level pool singleton picks them up on first use.
+function applyTestDatabaseUrl(): void {
+  const raw = process.env.TEST_DATABASE_URL;
+  if (!raw) return;
+  try {
+    const url = new URL(raw);
+    process.env.POSTGRES_HOST     = url.hostname;
+    process.env.POSTGRES_PORT     = url.port || '5432';
+    process.env.POSTGRES_DB       = url.pathname.replace(/^\//, '');
+    process.env.POSTGRES_USER     = url.username;
+    process.env.POSTGRES_PASSWORD = url.password;
+  } catch { /* leave env vars as-is */ }
+}
+
+applyTestDatabaseUrl();
+
+import { Pool } from 'pg';
+import { buildTestApp, makeTestToken, closePool } from './helpers.js';
+
+// ─── Fixture state ────────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let pool: Pool;
+let testCompanyId: string;
+let testStationId: string;
+let otherStationId: string;
+let otherCompanyId: string;
+
+const TEST_DATE = '2026-04-05';
+const createdIds: { playlists: string[]; entries: string[]; songs: string[]; categories: string[] } = {
+  playlists: [], entries: [], songs: [], categories: [],
+};
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+describe.skipIf(!process.env.TEST_DATABASE_URL)(
+  'GET /api/v1/stations/:id/analytics/category-distribution',
+  () => {
+    beforeAll(async () => {
+      pool = new Pool({ connectionString: process.env.TEST_DATABASE_URL });
+
+      // ── Company + Station ─────────────────────────────────────────────────
+      const co = await pool.query<{ id: string }>(
+        `INSERT INTO companies (name, slug)
+         VALUES ('Analytics Test Co', 'analytics-test-co-${Date.now()}')
+         RETURNING id`,
+      );
+      testCompanyId = co.rows[0].id;
+
+      const st = await pool.query<{ id: string }>(
+        `INSERT INTO stations (company_id, name, timezone, broadcast_start_hour, broadcast_end_hour, active_days)
+         VALUES ($1, 'Analytics Test Station', 'UTC', 0, 23,
+                 ARRAY['MON','TUE','WED','THU','FRI','SAT','SUN'])
+         RETURNING id`,
+        [testCompanyId],
+      );
+      testStationId = st.rows[0].id;
+
+      // ── Second company + station (for tenant isolation) ───────────────────
+      const co2 = await pool.query<{ id: string }>(
+        `INSERT INTO companies (name, slug)
+         VALUES ('Other Analytics Co', 'other-analytics-co-${Date.now()}')
+         RETURNING id`,
+      );
+      otherCompanyId = co2.rows[0].id;
+
+      const st2 = await pool.query<{ id: string }>(
+        `INSERT INTO stations (company_id, name, timezone, broadcast_start_hour, broadcast_end_hour, active_days)
+         VALUES ($1, 'Other Analytics Station', 'UTC', 0, 23, ARRAY['MON'])
+         RETURNING id`,
+        [otherCompanyId],
+      );
+      otherStationId = st2.rows[0].id;
+
+      // ── Categories ────────────────────────────────────────────────────────
+      const popCat = await pool.query<{ id: string }>(
+        `INSERT INTO categories (station_id, code, label, rotation_weight)
+         VALUES ($1, 'POP', 'Pop Music', 1.0)
+         RETURNING id`,
+        [testStationId],
+      );
+      const rnbCat = await pool.query<{ id: string }>(
+        `INSERT INTO categories (station_id, code, label, rotation_weight)
+         VALUES ($1, 'RNB', 'R&B', 1.0)
+         RETURNING id`,
+        [testStationId],
+      );
+      const popCatId = popCat.rows[0].id;
+      const rnbCatId = rnbCat.rows[0].id;
+      createdIds.categories.push(popCatId, rnbCatId);
+
+      // ── Songs ─────────────────────────────────────────────────────────────
+      const song1 = await pool.query<{ id: string }>(
+        `INSERT INTO songs (company_id, station_id, category_id, title, artist)
+         VALUES ($1, $2, $3, 'Pop Track', 'Artist A')
+         RETURNING id`,
+        [testCompanyId, testStationId, popCatId],
+      );
+      const song2 = await pool.query<{ id: string }>(
+        `INSERT INTO songs (company_id, station_id, category_id, title, artist)
+         VALUES ($1, $2, $3, 'RnB Track', 'Artist B')
+         RETURNING id`,
+        [testCompanyId, testStationId, rnbCatId],
+      );
+      const songPopId = song1.rows[0].id;
+      const songRnbId = song2.rows[0].id;
+      createdIds.songs.push(songPopId, songRnbId);
+
+      // ── Playlist + entries for TEST_DATE ──────────────────────────────────
+      const pl = await pool.query<{ id: string }>(
+        `INSERT INTO playlists (station_id, date, status)
+         VALUES ($1, $2, 'ready')
+         RETURNING id`,
+        [testStationId, TEST_DATE],
+      );
+      const playlistId = pl.rows[0].id;
+      createdIds.playlists.push(playlistId);
+
+      // 3 Pop entries + 1 RnB entry → 75% / 25%
+      const e1 = await pool.query<{ id: string }>(
+        `INSERT INTO playlist_entries (playlist_id, hour, position, song_id)
+         VALUES ($1, 8, 1, $2) RETURNING id`,
+        [playlistId, songPopId],
+      );
+      const e2 = await pool.query<{ id: string }>(
+        `INSERT INTO playlist_entries (playlist_id, hour, position, song_id)
+         VALUES ($1, 9, 1, $2) RETURNING id`,
+        [playlistId, songPopId],
+      );
+      const e3 = await pool.query<{ id: string }>(
+        `INSERT INTO playlist_entries (playlist_id, hour, position, song_id)
+         VALUES ($1, 10, 1, $2) RETURNING id`,
+        [playlistId, songPopId],
+      );
+      const e4 = await pool.query<{ id: string }>(
+        `INSERT INTO playlist_entries (playlist_id, hour, position, song_id)
+         VALUES ($1, 11, 1, $2) RETURNING id`,
+        [playlistId, songRnbId],
+      );
+      createdIds.entries.push(e1.rows[0].id, e2.rows[0].id, e3.rows[0].id, e4.rows[0].id);
+
+      app = await buildTestApp();
+    });
+
+    afterAll(async () => {
+      await app?.close();
+      if (pool) {
+        if (createdIds.entries.length > 0) {
+          await pool.query(
+            `DELETE FROM playlist_entries WHERE id = ANY($1::uuid[])`,
+            [createdIds.entries],
+          );
+        }
+        if (createdIds.playlists.length > 0) {
+          await pool.query(
+            `DELETE FROM playlists WHERE id = ANY($1::uuid[])`,
+            [createdIds.playlists],
+          );
+        }
+        if (createdIds.songs.length > 0) {
+          await pool.query(
+            `DELETE FROM songs WHERE id = ANY($1::uuid[])`,
+            [createdIds.songs],
+          );
+        }
+        if (createdIds.categories.length > 0) {
+          await pool.query(
+            `DELETE FROM categories WHERE id = ANY($1::uuid[])`,
+            [createdIds.categories],
+          );
+        }
+        await pool.query(
+          `DELETE FROM stations WHERE id = ANY($1::uuid[])`,
+          [[testStationId, otherStationId]],
+        );
+        await pool.query(
+          `DELETE FROM companies WHERE id = ANY($1::uuid[])`,
+          [[testCompanyId, otherCompanyId]],
+        );
+        await pool.end();
+      }
+      await closePool();
+    });
+
+    // ─── Auth ──────────────────────────────────────────────────────────────
+
+    it('returns 401 without a token', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${testStationId}/analytics/category-distribution?date=${TEST_DATE}`,
+      });
+      expect(res.statusCode).toBe(401);
+    });
+
+    // ─── Validation ────────────────────────────────────────────────────────
+
+    it('returns 400 on a bad date format', async () => {
+      const token = makeTestToken({
+        company_id: testCompanyId,
+        station_ids: [testStationId],
+        role_code: 'company_admin',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${testStationId}/analytics/category-distribution?date=05-04-2026`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    // ─── Tenant isolation ──────────────────────────────────────────────────
+
+    it('returns 403 when user does not have access to the station', async () => {
+      // Token scoped to testStationId only — accessing otherStationId must fail
+      const token = makeTestToken({
+        company_id: testCompanyId,
+        station_ids: [testStationId],
+        role_code: 'station_manager',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${otherStationId}/analytics/category-distribution?date=${TEST_DATE}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(res.statusCode).toBe(403);
+    });
+
+    // ─── Happy path ────────────────────────────────────────────────────────
+
+    it('returns category distribution for a scheduled date', async () => {
+      const token = makeTestToken({
+        company_id: testCompanyId,
+        station_ids: [testStationId],
+        role_code: 'company_admin',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${testStationId}/analytics/category-distribution?date=${TEST_DATE}`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as Array<{
+        category_code: string;
+        category_label: string;
+        total_plays: number;
+        percentage: number;
+      }>;
+
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThanOrEqual(2);
+
+      const pop = body.find((r) => r.category_code === 'POP');
+      const rnb = body.find((r) => r.category_code === 'RNB');
+
+      expect(pop).toBeDefined();
+      expect(pop!.total_plays).toBe(3);
+      expect(pop!.percentage).toBe(75);
+
+      expect(rnb).toBeDefined();
+      expect(rnb!.total_plays).toBe(1);
+      expect(rnb!.percentage).toBe(25);
+    });
+
+    it('returns an empty array when no playlist is scheduled for the date', async () => {
+      const token = makeTestToken({
+        company_id: testCompanyId,
+        station_ids: [testStationId],
+        role_code: 'company_admin',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${testStationId}/analytics/category-distribution?date=2000-01-01`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as unknown[];
+      expect(body).toEqual([]);
+    });
+
+    // ─── Backward-compat: ?days=N still works ──────────────────────────────
+
+    it('returns an array when querying with ?days=N (backward compat)', async () => {
+      const token = makeTestToken({
+        company_id: testCompanyId,
+        station_ids: [testStationId],
+        role_code: 'company_admin',
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/v1/stations/${testStationId}/analytics/category-distribution?days=7`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(Array.isArray(JSON.parse(res.body))).toBe(true);
+    });
+  },
+);

--- a/services/analytics/tests/integration/helpers.ts
+++ b/services/analytics/tests/integration/helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Test helpers for analytics service integration tests.
+ *
+ * Builds a Fastify app in-process (no HTTP port binding) using Fastify's
+ * built-in inject() for HTTP simulation.
+ */
+
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+import jwt from 'jsonwebtoken';
+import { analyticsRoutes } from '../../src/routes/analytics.js';
+import { getPool } from '../../src/db.js';
+
+const JWT_SECRET = process.env.JWT_ACCESS_SECRET ?? 'dev-access-secret-change-in-prod';
+
+/**
+ * Build a testable Fastify instance.
+ * Routes are registered identically to the production app,
+ * but the server is never bound to a port.
+ */
+export async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+
+  await app.register(sensible);
+  await app.register(analyticsRoutes, { prefix: '/api/v1' });
+
+  app.setErrorHandler((err, _req, reply) => {
+    if (err.validation) {
+      return reply.code(400).send({
+        error: { code: 'VALIDATION_ERROR', message: err.message, details: err.validation },
+      });
+    }
+    return reply
+      .code(500)
+      .send({ error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } });
+  });
+
+  await app.ready();
+  return app;
+}
+
+/**
+ * Generate a signed JWT for test requests.
+ * Uses the same secret the `authenticate` middleware validates against.
+ */
+export function makeTestToken(overrides: Partial<{
+  sub: string;
+  company_id: string;
+  station_ids: string[];
+  role_code: string;
+  permissions: string[];
+}> = {}): string {
+  const payload = {
+    sub: overrides.sub ?? 'test-user-id',
+    company_id: overrides.company_id ?? 'test-company-id',
+    station_ids: overrides.station_ids ?? [],
+    role_code: overrides.role_code ?? 'company_admin',
+    permissions: overrides.permissions ?? [
+      'analytics:read', 'library:read',
+    ],
+  };
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
+}
+
+/** Close the shared pg Pool after all tests in a file. */
+export async function closePool(): Promise<void> {
+  await getPool().end();
+}

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -15,6 +15,7 @@ Before starting any task, an agent MUST:
 ## Active Work
 - [ ] Deployment monitoring agent — Vercel + Railway error alerting (issue #166, feat/issue-166-deployment-monitor) | @claude-code | 2026-04-05
 - [ ] Fix high vulnerabilities (Next.js upgrade, Fastify upgrade, tar override) | @gemini-cli | 2026-04-04
+- [ ] Script review UI (issue #31, feat/issue-31-script-review-ui) | @claude-code | 2026-04-05
 - [ ] Re-generate single playlist slot (issue #132, feat/issue-132-slot-regen) | @claude-code | 2026-04-05
 - [ ] Generation failure alerting — endpoint + UI red badge (issue #133, feat/issue-133-generation-failure-alerting) | @claude-code | 2026-04-05
 - [ ] Category distribution report by date + chart (issue #134, feat/issue-134-category-distribution-by-date) | @claude-code | 2026-04-05


### PR DESCRIPTION
## Summary

- Backend `GET /api/v1/stations/:id/analytics/category-distribution?date=YYYY-MM-DD` was already implemented (route + service function `getCategoryDistributionByDate` using `playlist_entries` rather than `play_history`, so it works even before songs air)
- Frontend analytics page already shows a horizontal bar chart with a date picker scoped to the selected station
- Nginx `location` block already covers `^/api/v1/stations/[^/]+/analytics`
- This PR adds the missing test coverage required by the acceptance criteria

**New files / changes:**
- `services/analytics/src/services/analyticsService.test.ts` — 5 new unit tests for `getCategoryDistributionByDate` (happy path, empty result, zero percentage, SQL param verification, `playlist_entries` source verification)
- `services/analytics/tests/integration/helpers.ts` — Fastify inject helper + JWT factory for analytics integration tests
- `services/analytics/tests/integration/categoryDistribution.test.ts` — 6 integration tests: 401 auth, 400 bad date format, 403 tenant isolation, happy path (3 POP / 1 RnB → 75%/25%), empty date, backward-compat `?days=N`
- `services/analytics/package.json` — add `test:integration` script; scope `test:unit` to `src/` only

## Test plan

- [ ] `pnpm run typecheck` — passes
- [ ] `pnpm run lint` — passes (0 errors, pre-existing warnings only)
- [ ] `pnpm run test:unit` — 15/15 analytics unit tests pass, all services green
- [ ] Integration tests skip gracefully without `TEST_DATABASE_URL` (`.skipIf` guard)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)