### PR TITLE
feat(dj): OpenAI GPT LLM adapter + Google Cloud TTS adapter (#25)

### DIFF
--- a/services/dj/src/adapters/llm/openai.ts
+++ b/services/dj/src/adapters/llm/openai.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenAI Chat LLM adapter — calls api.openai.com directly (GPT-4o / GPT-4o-mini).
+ * Follows the same interface as the OpenRouter adapter so callers can swap providers.
+ */
+import OpenAI from 'openai';
+import { config } from '../../config.js';
+import type { LlmMessage, LlmOptions } from './openrouter.js';
+
+export type { LlmMessage, LlmOptions };
+
+let defaultClient: OpenAI | null = null;
+
+function getClient(apiKey?: string): OpenAI {
+  if (apiKey) {
+    return new OpenAI({ apiKey });
+  }
+  if (!defaultClient) {
+    defaultClient = new OpenAI({ apiKey: config.llm.openaiApiKey });
+  }
+  return defaultClient;
+}
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+
+export async function openAiLlmComplete(
+  messages: LlmMessage[],
+  options: LlmOptions = {},
+): Promise<string> {
+  const c = getClient(options.apiKey);
+  const model = options.model ?? DEFAULT_MODEL;
+
+  const response = await c.chat.completions.create({
+    model,
+    messages,
+    temperature: options.temperature ?? 0.8,
+    max_tokens: options.maxTokens ?? 512,
+  });
+
+  const text = response.choices[0]?.message?.content;
+  if (!text) throw new Error('OpenAI LLM returned empty response');
+  return text.trim();
+}

--- a/services/dj/src/adapters/llm/openrouter.ts
+++ b/services/dj/src/adapters/llm/openrouter.ts
@@ -10,8 +10,10 @@ export interface LlmOptions {
   model?: string;
   temperature?: number;
   maxTokens?: number;
-  /** Override the OpenRouter API key (e.g. read from station_settings). */
+  /** Override the API key (e.g. read from station_settings). */
   apiKey?: string;
+  /** LLM provider: 'openrouter' (default) | 'openai' */
+  provider?: string;
 }
 
 let defaultClient: OpenAI | null = null;
@@ -45,6 +47,13 @@ export async function llmComplete(
   messages: LlmMessage[],
   options: LlmOptions = {},
 ): Promise<string> {
+  // Dispatch to OpenAI direct if requested
+  const provider = options.provider ?? config.llm.provider;
+  if (provider === 'openai') {
+    const { openAiLlmComplete } = await import('./openai.js');
+    return openAiLlmComplete(messages, options);
+  }
+
   const c = getClient(options.apiKey);
   const model = options.model ?? config.openRouter.defaultModel;
 

--- a/services/dj/src/adapters/tts/google.ts
+++ b/services/dj/src/adapters/tts/google.ts
@@ -1,0 +1,76 @@
+/**
+ * Google Cloud Text-to-Speech adapter.
+ * Uses the REST API directly (no SDK dependency needed).
+ * Docs: https://cloud.google.com/text-to-speech/docs/reference/rest/v1/text/synthesize
+ */
+import { config } from '../../config.js';
+import type { TtsAdapter, TtsOptions, TtsResult } from './interface.js';
+
+const GOOGLE_TTS_URL = 'https://texttospeech.googleapis.com/v1/text:synthesize';
+
+// Curated list of high-quality Google TTS voices
+export const GOOGLE_TTS_VOICES = [
+  { id: 'en-US-Neural2-A', name: 'Neural2 A (US Male)', provider: 'google' as const },
+  { id: 'en-US-Neural2-C', name: 'Neural2 C (US Female)', provider: 'google' as const },
+  { id: 'en-US-Neural2-D', name: 'Neural2 D (US Male)', provider: 'google' as const },
+  { id: 'en-US-Neural2-F', name: 'Neural2 F (US Female)', provider: 'google' as const },
+  { id: 'en-US-Wavenet-A', name: 'WaveNet A (US Male)', provider: 'google' as const },
+  { id: 'en-US-Wavenet-C', name: 'WaveNet C (US Female)', provider: 'google' as const },
+  { id: 'en-US-Wavenet-D', name: 'WaveNet D (US Male)', provider: 'google' as const },
+  { id: 'en-US-Wavenet-F', name: 'WaveNet F (US Female)', provider: 'google' as const },
+  { id: 'en-GB-Neural2-A', name: 'Neural2 A (UK Female)', provider: 'google' as const },
+  { id: 'en-GB-Neural2-B', name: 'Neural2 B (UK Male)', provider: 'google' as const },
+  { id: 'en-AU-Neural2-A', name: 'Neural2 A (AU Female)', provider: 'google' as const },
+  { id: 'en-AU-Neural2-B', name: 'Neural2 B (AU Male)', provider: 'google' as const },
+];
+
+export class GoogleTtsAdapter implements TtsAdapter {
+  private apiKey: string;
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey ?? config.tts.googleApiKey;
+  }
+
+  async generate(opts: TtsOptions): Promise<TtsResult> {
+    // Voice IDs follow BCP-47 convention: e.g. "en-US-Neural2-A"
+    // Extract language code from the voice name prefix
+    const parts = opts.voice_id.split('-');
+    const languageCode = parts.length >= 2 ? `${parts[0]}-${parts[1]}` : 'en-US';
+
+    const body = {
+      input: { text: opts.text },
+      voice: {
+        languageCode,
+        name: opts.voice_id,
+      },
+      audioConfig: {
+        audioEncoding: 'MP3',
+        speakingRate: 1.0,
+        pitch: 0.0,
+      },
+    };
+
+    const res = await fetch(`${GOOGLE_TTS_URL}?key=${this.apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Google TTS failed (${res.status}): ${errText}`);
+    }
+
+    const json = await res.json() as { audioContent: string };
+    const audioData = Buffer.from(json.audioContent, 'base64');
+
+    // Estimate duration: MP3 at 24kbps (Google default) ≈ 3000 bytes/sec
+    const duration_sec = audioData.length / 3000;
+
+    return { audio_data: audioData, duration_sec };
+  }
+
+  listVoices() {
+    return Promise.resolve(GOOGLE_TTS_VOICES);
+  }
+}

--- a/services/dj/src/adapters/tts/openai.ts
+++ b/services/dj/src/adapters/tts/openai.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import { config } from '../../config.js';
 import { ElevenLabsTtsAdapter } from './elevenlabs.js';
+import { GoogleTtsAdapter } from './google.js';
 import type { TtsAdapter, TtsOptions, TtsResult } from './interface.js';
 
 export interface TtsAdapterOverrides {
@@ -32,8 +33,7 @@ export class OpenAiTtsAdapter implements TtsAdapter {
 export function getTtsAdapter(overrides?: TtsAdapterOverrides): TtsAdapter {
   const provider = overrides?.provider ?? config.tts.provider;
   if (provider === 'openai') return new OpenAiTtsAdapter(overrides?.apiKey);
-  if (provider === 'elevenlabs') {
-    return new ElevenLabsTtsAdapter(overrides?.apiKey);
-  }
+  if (provider === 'elevenlabs') return new ElevenLabsTtsAdapter(overrides?.apiKey);
+  if (provider === 'google') return new GoogleTtsAdapter(overrides?.apiKey);
   throw new Error(`TTS provider "${provider}" not yet implemented`);
 }

--- a/services/dj/src/config.ts
+++ b/services/dj/src/config.ts
@@ -10,7 +10,14 @@ export const config = {
     password: process.env.REDIS_PASSWORD ?? undefined,
   },
 
-  // OpenRouter (LLM)
+  // LLM providers
+  llm: {
+    /** 'openrouter' (default) | 'openai' */
+    provider: process.env.LLM_PROVIDER ?? 'openrouter',
+    openaiApiKey: process.env.OPENAI_API_KEY ?? '',
+  },
+
+  // OpenRouter (LLM via OpenRouter gateway)
   openRouter: {
     apiKey: process.env.OPENROUTER_API_KEY ?? '',
     baseUrl: process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
@@ -19,11 +26,13 @@ export const config = {
     siteName: process.env.OPENROUTER_SITE_NAME ?? 'PlayGen',
   },
 
-  // TTS (OpenAI — pluggable via adapter)
+  // TTS (pluggable via adapter)
   tts: {
+    /** 'openai' (default) | 'elevenlabs' | 'google' */
     provider: process.env.TTS_PROVIDER ?? 'openai',
     openaiApiKey: process.env.OPENAI_API_KEY ?? '',
     elevenlabsApiKey: process.env.ELEVENLABS_API_KEY ?? '',
+    googleApiKey: process.env.GOOGLE_TTS_API_KEY ?? '',
     defaultVoice: process.env.TTS_DEFAULT_VOICE ?? 'alloy',
   },
 

--- a/services/dj/src/routes/profiles.ts
+++ b/services/dj/src/routes/profiles.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { authenticate } from '@playgen/middleware';
 import * as profileService from '../services/profileService.js';
 import { listElevenLabsVoices } from '../adapters/tts/elevenlabs.js';
+import { GOOGLE_TTS_VOICES } from '../adapters/tts/google.js';
 import { config } from '../config.js';
 import { getPool } from '../db.js';
 
@@ -66,6 +67,6 @@ export async function profileRoutes(app: FastifyInstance): Promise<void> {
 
     const elevenlabsVoices = await listElevenLabsVoices(elevenLabsKey || undefined);
 
-    return [...OPENAI_VOICES, ...elevenlabsVoices];
+    return [...OPENAI_VOICES, ...elevenlabsVoices, ...GOOGLE_TTS_VOICES];
   });
 }

--- a/services/dj/tests/unit/googleTts.test.ts
+++ b/services/dj/tests/unit/googleTts.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/config', () => ({
+  config: {
+    tts: {
+      googleApiKey: 'test-google-key',
+      provider: 'google',
+    },
+  },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { GoogleTtsAdapter, GOOGLE_TTS_VOICES } from '../../src/adapters/tts/google';
+
+describe('GoogleTtsAdapter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('synthesizes speech and returns a Buffer', async () => {
+    const fakeAudio = Buffer.from('fake-mp3-data').toString('base64');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ audioContent: fakeAudio }),
+    });
+
+    const adapter = new GoogleTtsAdapter('test-key');
+    const result = await adapter.generate({ voice_id: 'en-US-Neural2-A', text: 'Hello radio!' });
+
+    expect(result.audio_data).toBeInstanceOf(Buffer);
+    expect(result.audio_data.length).toBeGreaterThan(0);
+    expect(result.duration_sec).toBeGreaterThan(0);
+  });
+
+  it('sends correct voice name and language code', async () => {
+    const fakeAudio = Buffer.from('audio').toString('base64');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ audioContent: fakeAudio }),
+    });
+
+    const adapter = new GoogleTtsAdapter('test-key');
+    await adapter.generate({ voice_id: 'en-GB-Neural2-B', text: 'Test' });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain('texttospeech.googleapis.com');
+    const body = JSON.parse(init.body);
+    expect(body.voice.name).toBe('en-GB-Neural2-B');
+    expect(body.voice.languageCode).toBe('en-GB');
+    expect(body.audioConfig.audioEncoding).toBe('MP3');
+  });
+
+  it('includes API key in URL', async () => {
+    const fakeAudio = Buffer.from('a').toString('base64');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ audioContent: fakeAudio }),
+    });
+
+    const adapter = new GoogleTtsAdapter('my-api-key');
+    await adapter.generate({ voice_id: 'en-US-Wavenet-A', text: 'Test' });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('key=my-api-key');
+  });
+
+  it('throws on API error', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: vi.fn().mockResolvedValue('API key invalid'),
+    });
+
+    const adapter = new GoogleTtsAdapter('bad-key');
+    await expect(
+      adapter.generate({ voice_id: 'en-US-Neural2-A', text: 'Hello' }),
+    ).rejects.toThrow('Google TTS failed (403): API key invalid');
+  });
+
+  it('listVoices returns curated Google voice list', async () => {
+    const adapter = new GoogleTtsAdapter();
+    const voices = await adapter.listVoices();
+    expect(voices.length).toBeGreaterThan(0);
+    expect(voices[0].provider).toBe('google');
+    expect(voices[0].id).toContain('en-');
+  });
+
+  it('GOOGLE_TTS_VOICES exports curated list with provider=google', () => {
+    expect(GOOGLE_TTS_VOICES.length).toBeGreaterThan(0);
+    expect(GOOGLE_TTS_VOICES.every(v => v.provider === 'google')).toBe(true);
+  });
+});

--- a/services/dj/tests/unit/openaiLlm.test.ts
+++ b/services/dj/tests/unit/openaiLlm.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCreate = vi.fn().mockResolvedValue({
+  choices: [{ message: { content: 'Hello from GPT-4o!' } }],
+});
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(class {
+    chat = { completions: { create: mockCreate } };
+  }),
+}));
+
+vi.mock('../../src/config', () => ({
+  config: {
+    llm: { provider: 'openai', openaiApiKey: 'test-openai-key' },
+    openRouter: { defaultModel: 'anthropic/claude-sonnet-4-5' },
+  },
+}));
+
+import { openAiLlmComplete } from '../../src/adapters/llm/openai';
+
+describe('OpenAiLlmAdapter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns trimmed text from GPT-4o response', async () => {
+    const result = await openAiLlmComplete([
+      { role: 'system', content: 'You are Alex, a radio DJ.' },
+      { role: 'user', content: 'Introduce the next song.' },
+    ]);
+    expect(result).toBe('Hello from GPT-4o!');
+  });
+
+  it('uses gpt-4o-mini as default model', async () => {
+    await openAiLlmComplete([{ role: 'user', content: 'test' }]);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4o-mini' }),
+    );
+  });
+
+  it('accepts optional model and temperature', async () => {
+    await openAiLlmComplete(
+      [{ role: 'user', content: 'test' }],
+      { model: 'gpt-4o', temperature: 0.3 },
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'gpt-4o', temperature: 0.3 }),
+    );
+  });
+
+  it('throws on empty LLM response', async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: '' } }] });
+    await expect(
+      openAiLlmComplete([{ role: 'user', content: 'test' }]),
+    ).rejects.toThrow('OpenAI LLM returned empty response');
+  });
+});


### PR DESCRIPTION
## Summary
- **OpenAI Chat adapter** (`adapters/llm/openai.ts`): Direct GPT-4o/GPT-4o-mini calls via `api.openai.com`, dispatched when `LLM_PROVIDER=openai`
- **Google Cloud TTS adapter** (`adapters/tts/google.ts`): REST API integration with 12 curated Neural2/WaveNet voices (en-US, en-GB, en-AU)
- Both registered in their respective factories (`getTtsAdapter`, `llmComplete` dispatcher)
- `GET /dj/tts/voices` now returns voices from all 3 TTS providers (OpenAI + ElevenLabs + Google)
- Config: added `LLM_PROVIDER`, `GOOGLE_TTS_API_KEY` env vars

## Test plan
- [x] `pnpm --filter @playgen/dj-service run test:unit` — 9 files, 50 tests passing
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [ ] Integration: set `LLM_PROVIDER=openai` + `OPENAI_API_KEY` and verify script generation uses GPT-4o-mini
- [ ] Integration: set `TTS_PROVIDER=google` + `GOOGLE_TTS_API_KEY` and verify audio generates

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)