### PR TITLE
fix(gateway): route generation-failures to scheduler service

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -95,6 +95,14 @@ server {
         proxy_set_header X-Request-ID $request_id;
     }
 
+    # ─── Scheduler: generation failures ──────────────────────────
+    location ~ ^/api/v1/stations/[^/]+/generation-failures {
+        proxy_pass http://scheduler;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
+    }
+
     # ─── Playlist: station playlists list ────────────────────────
     location ~ ^/api/v1/stations/[^/]+/playlists {
         proxy_pass http://playlist;


### PR DESCRIPTION
## Summary
- `GET /api/v1/stations/:id/generation-failures` was missing a specific nginx location block, causing it to fall through to the station catch-all and hit the wrong upstream (station service → 404)
- Added explicit rule before the station catch-all to proxy this path to the scheduler service where the handler lives

## Root cause
nginx processes `location ~` blocks in **declaration order**, not specificity order. Without an explicit block for `/generation-failures`, requests matched the generic `^/api/v1/stations` catch-all and were sent to the station service.

## Test plan
- [ ] `GET /api/v1/stations/:id/generation-failures` returns 200 (or empty array) from scheduler, not 404 from station
- [ ] Generation failure UI badge correctly shows failed job count in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)