### PR TITLE
feat(dj): wire Settings API keys to DJ worker, add Anthropic direct LLM adapter

### DIFF
--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -19,6 +19,7 @@ interface StationConfig {
   openai_api_key?: string;
   elevenlabs_api_key?: string;
   openrouter_api_key?: string;
+  anthropic_api_key?: string;
 }
 
 interface RotationRules {
@@ -38,6 +39,7 @@ const DEFAULT_CONFIG: StationConfig = {
   openai_api_key: '',
   elevenlabs_api_key: '',
   openrouter_api_key: '',
+  anthropic_api_key: '',
 };
 
 const DEFAULT_RULES: RotationRules = {
@@ -351,6 +353,18 @@ export default function SettingsPage() {
                       onChange={(e) => setConfig((p) => ({ ...p, elevenlabs_api_key: e.target.value }))}
                       className="input w-full"
                       placeholder="eleven-..."
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-300 mb-0.5">Anthropic API Key</label>
+                    <p className="text-xs text-gray-500 mb-2">Used for direct Anthropic script generation (if provider is set to Anthropic)</p>
+                    <input
+                      type="password"
+                      value={config.anthropic_api_key || ''}
+                      onChange={(e) => setConfig((p) => ({ ...p, anthropic_api_key: e.target.value }))}
+                      className="input w-full"
+                      placeholder="sk-ant-..."
                     />
                   </div>
                 </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
 
   services/dj:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.39.0
+        version: 0.39.0
       '@aws-sdk/client-s3':
         specifier: ^3.717.0
         version: 3.1024.0
@@ -456,6 +459,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -3373,6 +3379,18 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.39.0':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/services/dj/package.json
+++ b/services/dj/package.json
@@ -11,6 +11,7 @@
     "test:integration": "vitest run tests/integration"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@aws-sdk/client-s3": "^3.717.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/sensible": "^6.0.0",

--- a/services/dj/src/adapters/llm/anthropic.ts
+++ b/services/dj/src/adapters/llm/anthropic.ts
@@ -1,0 +1,52 @@
+/**
+ * Anthropic direct LLM adapter — calls api.anthropic.com using the Anthropic SDK.
+ * Follows the same interface as the OpenRouter/OpenAI adapters so callers can swap providers.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { config } from '../../config.js';
+import type { LlmMessage, LlmOptions } from './openrouter.js';
+
+export type { LlmMessage, LlmOptions };
+
+let defaultClient: Anthropic | null = null;
+
+function getClient(apiKey?: string): Anthropic {
+  if (apiKey) {
+    return new Anthropic({ apiKey });
+  }
+  if (!defaultClient) {
+    defaultClient = new Anthropic({ apiKey: config.llm.anthropicApiKey });
+  }
+  return defaultClient;
+}
+
+const DEFAULT_MODEL = 'claude-3-5-haiku-20241022';
+
+export async function anthropicLlmComplete(
+  messages: LlmMessage[],
+  options: LlmOptions = {},
+): Promise<string> {
+  const c = getClient(options.apiKey);
+  const model = options.model ?? DEFAULT_MODEL;
+
+  // Anthropic API separates system prompt from user/assistant messages
+  const systemMessages = messages.filter((m) => m.role === 'system');
+  const nonSystemMessages = messages.filter((m) => m.role !== 'system');
+
+  const systemPrompt = systemMessages.map((m) => m.content).join('\n');
+
+  const response = await c.messages.create({
+    model,
+    max_tokens: options.maxTokens ?? 512,
+    temperature: options.temperature ?? 0.8,
+    ...(systemPrompt ? { system: systemPrompt } : {}),
+    messages: nonSystemMessages.map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    })),
+  });
+
+  const block = response.content[0];
+  if (!block || block.type !== 'text') throw new Error('Anthropic LLM returned empty response');
+  return block.text.trim();
+}

--- a/services/dj/src/adapters/llm/openrouter.ts
+++ b/services/dj/src/adapters/llm/openrouter.ts
@@ -47,11 +47,15 @@ export async function llmComplete(
   messages: LlmMessage[],
   options: LlmOptions = {},
 ): Promise<string> {
-  // Dispatch to OpenAI direct if requested
+  // Dispatch to the appropriate provider
   const provider = options.provider ?? config.llm.provider;
   if (provider === 'openai') {
     const { openAiLlmComplete } = await import('./openai.js');
     return openAiLlmComplete(messages, options);
+  }
+  if (provider === 'anthropic') {
+    const { anthropicLlmComplete } = await import('./anthropic.js');
+    return anthropicLlmComplete(messages, options);
   }
 
   const c = getClient(options.apiKey);

--- a/services/dj/src/config.ts
+++ b/services/dj/src/config.ts
@@ -12,9 +12,10 @@ export const config = {
 
   // LLM providers
   llm: {
-    /** 'openrouter' (default) | 'openai' */
+    /** 'openrouter' (default) | 'openai' | 'anthropic' */
     provider: process.env.LLM_PROVIDER ?? 'openrouter',
     openaiApiKey: process.env.OPENAI_API_KEY ?? '',
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? '',
   },
 
   // OpenRouter (LLM via OpenRouter gateway)

--- a/services/dj/src/workers/generationWorker.ts
+++ b/services/dj/src/workers/generationWorker.ts
@@ -30,6 +30,10 @@ interface StationRow {
   name: string;
   timezone: string;
   company_id: string;
+  openrouter_api_key: string | null;
+  openai_api_key: string | null;
+  elevenlabs_api_key: string | null;
+  anthropic_api_key: string | null;
 }
 
 // Determine which segment types to generate for a given playlist position
@@ -53,9 +57,11 @@ export async function runGenerationJob(data: DjGenerationJobData): Promise<void>
   const pool = getPool();
   const start = Date.now();
 
-  // 1. Load station info
+  // 1. Load station info (including API key columns saved via Settings page)
   const { rows: stationRows } = await pool.query<StationRow>(
-    `SELECT id, name, timezone, company_id FROM stations WHERE id = $1`,
+    `SELECT id, name, timezone, company_id,
+            openrouter_api_key, openai_api_key, elevenlabs_api_key, anthropic_api_key
+     FROM stations WHERE id = $1`,
     [data.station_id],
   );
   const station = stationRows[0];
@@ -121,13 +127,22 @@ export async function runGenerationJob(data: DjGenerationJobData): Promise<void>
   const currentDate = new Date().toISOString().split('T')[0];
   let position = 0;
 
-  // Resolve effective TTS / LLM config: station setting overrides fall back to env vars.
+  // Resolve effective TTS / LLM config:
+  //   1. station_settings table (per-station override, keyed by string)
+  //   2. stations table columns (saved via the Settings page)
+  //   3. environment-variable defaults from config
   const effectiveTtsProvider = stationSettings['tts_provider'] ?? config.tts.provider;
-  const effectiveTtsApiKey   = stationSettings['tts_api_key']
-    ?? (effectiveTtsProvider === 'elevenlabs' ? config.tts.elevenlabsApiKey : config.tts.openaiApiKey);
+  const effectiveLlmProvider = stationSettings['llm_provider'] ?? config.llm.provider;
   const effectiveTtsVoiceId  = stationSettings['tts_voice_id'] ?? profile.tts_voice_id ?? config.tts.defaultVoice;
   const effectiveLlmModel    = stationSettings['llm_model'] ?? profile.llm_model;
-  const effectiveLlmApiKey   = stationSettings['llm_api_key'] ?? undefined;
+
+  const effectiveLlmApiKey = stationSettings['llm_api_key']
+    ?? (effectiveLlmProvider === 'anthropic' ? station.anthropic_api_key : station.openrouter_api_key)
+    ?? undefined;
+
+  const effectiveTtsApiKey = stationSettings['tts_api_key']
+    ?? (effectiveTtsProvider === 'elevenlabs' ? station.elevenlabs_api_key : station.openai_api_key)
+    ?? (effectiveTtsProvider === 'elevenlabs' ? config.tts.elevenlabsApiKey : config.tts.openaiApiKey);
 
   const ttsEnabled = !!(effectiveTtsApiKey);
 
@@ -176,7 +191,8 @@ export async function runGenerationJob(data: DjGenerationJobData): Promise<void>
         {
           model: effectiveLlmModel,
           temperature: profile.llm_temperature,
-          apiKey: effectiveLlmApiKey,
+          apiKey: effectiveLlmApiKey ?? undefined,
+          provider: effectiveLlmProvider,
         },
       );
 

--- a/services/scheduler/src/routes/config.ts
+++ b/services/scheduler/src/routes/config.ts
@@ -7,7 +7,7 @@ interface StationParams {
   id: string;
 }
 
-const SECRET_KEYS = ['openai_api_key', 'elevenlabs_api_key', 'openrouter_api_key'] as const;
+const SECRET_KEYS = ['openai_api_key', 'elevenlabs_api_key', 'openrouter_api_key', 'anthropic_api_key'] as const;
 
 function maskSecrets<T extends Record<string, unknown>>(row: T): T {
   const masked = { ...row };
@@ -97,8 +97,9 @@ export async function configRoutes(app: FastifyInstance): Promise<void> {
         openai_api_key?: string;
         elevenlabs_api_key?: string;
         openrouter_api_key?: string;
+        anthropic_api_key?: string;
       }>(
-        'SELECT timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key FROM stations WHERE id = $1',
+        'SELECT timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key, anthropic_api_key FROM stations WHERE id = $1',
         [stationId],
       );
 
@@ -121,6 +122,7 @@ export async function configRoutes(app: FastifyInstance): Promise<void> {
       openai_api_key?: string;
       elevenlabs_api_key?: string;
       openrouter_api_key?: string;
+      anthropic_api_key?: string;
     };
   }>(
     '/stations/:id/config',
@@ -141,12 +143,13 @@ export async function configRoutes(app: FastifyInstance): Promise<void> {
         openai_api_key?: string;
         elevenlabs_api_key?: string;
         openrouter_api_key?: string;
+        anthropic_api_key?: string;
       };
     }>, reply: FastifyReply) => {
       const stationId = req.params.id;
-      const { 
+      const {
         timezone, broadcast_start_hour, broadcast_end_hour, active_days,
-        openai_api_key, elevenlabs_api_key, openrouter_api_key
+        openai_api_key, elevenlabs_api_key, openrouter_api_key, anthropic_api_key
       } = req.body;
       const pool = getPool();
 
@@ -161,10 +164,11 @@ export async function configRoutes(app: FastifyInstance): Promise<void> {
       if (openai_api_key !== undefined) { fields.push(`openai_api_key = $${i++}`); values.push(openai_api_key); }
       if (elevenlabs_api_key !== undefined) { fields.push(`elevenlabs_api_key = $${i++}`); values.push(elevenlabs_api_key); }
       if (openrouter_api_key !== undefined) { fields.push(`openrouter_api_key = $${i++}`); values.push(openrouter_api_key); }
+      if (anthropic_api_key !== undefined) { fields.push(`anthropic_api_key = $${i++}`); values.push(anthropic_api_key); }
 
       if (!fields.length) {
         const current = await pool.query(
-          'SELECT timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key FROM stations WHERE id = $1',
+          'SELECT timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key, anthropic_api_key FROM stations WHERE id = $1',
           [stationId],
         );
         return reply.code(200).send(maskSecrets(current.rows[0]));
@@ -181,9 +185,10 @@ export async function configRoutes(app: FastifyInstance): Promise<void> {
         openai_api_key?: string;
         elevenlabs_api_key?: string;
         openrouter_api_key?: string;
+        anthropic_api_key?: string;
       }>(
         `UPDATE stations SET ${fields.join(', ')} WHERE id = $${i}
-         RETURNING timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key`,
+         RETURNING timezone, broadcast_start_hour, broadcast_end_hour, active_days, openai_api_key, elevenlabs_api_key, openrouter_api_key, anthropic_api_key`,
         values,
       );
 

--- a/shared/db/src/migrations/030_add_anthropic_api_key_to_stations.sql
+++ b/shared/db/src/migrations/030_add_anthropic_api_key_to_stations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stations ADD COLUMN IF NOT EXISTS anthropic_api_key TEXT;


### PR DESCRIPTION
## Summary

- **Root cause fixed**: API keys saved on the Settings page were stored in the `stations` table but the DJ generation worker only read from `station_settings` — keys were silently ignored. The worker now SELECTs the key columns from `stations` and uses them as an intermediate fallback (between `station_settings` overrides and env-var defaults).
- **Migration 030**: Adds `anthropic_api_key TEXT` column to `stations` via `IF NOT EXISTS` guard.
- **Anthropic direct adapter** (`services/dj/src/adapters/llm/anthropic.ts`): uses `@anthropic-ai/sdk` with `claude-3-5-haiku-20241022` as the default model; handles system-prompt separation per Anthropic API requirements.
- **Dispatch updated** in `openrouter.ts`: `provider='anthropic'` now routes to the new adapter alongside the existing `provider='openai'` path.
- **Scheduler config route** fully tracks `anthropic_api_key` (SECRET_KEYS masking, GET and PUT queries, body type).
- **Frontend Settings page**: new Anthropic API Key password input following the same pattern as the other key fields.

## Fallback resolution order (LLM key)

```
station_settings['llm_api_key']
  ?? (provider === 'anthropic' ? stations.anthropic_api_key : stations.openrouter_api_key)
  ?? undefined   ← falls back to env ANTHROPIC_API_KEY / OPENROUTER_API_KEY via config
```

Same pattern applies for TTS keys.

## Test plan

- [ ] Run `pnpm run typecheck` — all packages compile clean
- [ ] Run `pnpm run lint` — no violations
- [ ] Run `pnpm run test:unit` — all 155+ unit tests pass
- [ ] Apply migration 030 against a local DB and verify column is added
- [ ] Save an Anthropic key in Settings UI, trigger a DJ generation job, confirm the key is picked up from the `stations` row
- [ ] Confirm existing OpenRouter / OpenAI flow is unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)