### PR TITLE
feat(agent-ops): add /report command to tg-agent bot (issue #181)

### DIFF
--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -14,8 +14,6 @@ Before starting any task, an agent MUST:
 
 ## Active Work
 - [ ] Fix DJ Script generation INTERNAL_ERROR — missing API key validation + unmasked LLM errors (issue #183, fix/issue-183) | @claude-code | 2026-04-05
-- [ ] bootstrap.sh: tasks/TODO.md stub + --help-board-ids + macOS sed fix (issue #179, feat/issue-179) | @claude-code | 2026-04-05
-- [ ] tg-agent: add /report command (issue #181, feat/issue-181) | @claude-code | 2026-04-05
 
 ## Recently Completed
 - [x] Google OAuth login (issue #200, feat/issue-200-google-oauth) | @claude-code | 2026-04-05

--- a/tools/agent-ops/tg-agent/bot.py
+++ b/tools/agent-ops/tg-agent/bot.py
@@ -89,6 +89,7 @@ def handle(text: str):
             "/ci — last 5 CI runs\n"
             "/issues — open bugs and features\n"
             "/pool — daemon pool status\n"
+            "/report — latest PM report\n"
             "/merge <pr_num> — squash-merge a PR\n"
             "/help — this message"
         )
@@ -136,6 +137,17 @@ def handle(text: str):
         )
         return f"📋 Open Issues:\n\nBugs:\n{bugs or 'none'}\n\nFeatures:\n{feats or 'none'}"
 
+    elif text == "/report":
+        report_file = "/state/pm-report.txt"
+        if os.path.exists(report_file):
+            try:
+                with open(report_file) as f:
+                    content = f.read().strip()
+                return f"📋 PM Report:\n{content[:3800]}"
+            except Exception as e:
+                return f"Error reading PM report: {e}"
+        return "📋 No PM report available."
+
     elif text == "/pool":
         # Read pool status from state file
         state_file = "/state/agent-state.json"
@@ -172,7 +184,20 @@ def handle(text: str):
             except Exception as e:
                 registry_info = f"\nRegistry read error: {e}"
 
-        return f"🤖 Pool Status:\n{info}{registry_info}"
+        # PM report timestamp
+        report_file = "/state/pm-report.txt"
+        if os.path.exists(report_file):
+            try:
+                import datetime
+                mtime = os.path.getmtime(report_file)
+                ts = datetime.datetime.fromtimestamp(mtime).strftime("%Y-%m-%d %H:%M")
+                pm_report_info = f"\n\nLast PM report: {ts}"
+            except Exception:
+                pm_report_info = ""
+        else:
+            pm_report_info = "\n\nLast PM report: none yet"
+
+        return f"🤖 Pool Status:\n{info}{registry_info}{pm_report_info}"
 
     elif text.startswith("/merge "):
         parts = text.split()
@@ -192,7 +217,7 @@ def main():
     print(f"🟢 {PROJECT_NAME} Telegram bot polling started", flush=True)
     tg_send(
         f"🟢 {PROJECT_NAME} bot online.\n"
-        f"Commands: /status /health /prs /ci /issues /pool /merge <pr> /help"
+        f"Commands: /status /health /prs /ci /issues /pool /report /merge <pr> /help"
     )
 
     while True:


### PR DESCRIPTION
## Summary

- `/report` command reads `/state/pm-report.txt` and returns its content; falls back gracefully with "No PM report available." if the file doesn't exist
- `/pool` now appends the last PM report timestamp (derived from file mtime) to its output
- `/help` and startup message updated to include `/report`

## Acceptance Criteria
- [x] `/report` command reads and displays `/state/pm-report.txt`
- [x] Falls back to 'No PM report available.' if file doesn't exist
- [x] `/pool` command shows timestamp of last PM report

## Test plan
- [ ] Run `/report` when `/state/pm-report.txt` does not exist → should return "No PM report available."
- [ ] Create `/state/pm-report.txt` with sample content, run `/report` → should return content
- [ ] Run `/pool` → output should include "Last PM report: YYYY-MM-DD HH:MM" or "Last PM report: none yet"
- [ ] Run `/help` → output should include `/report — latest PM report`

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)