### PR TITLE
fix(dj): surface TTS 400 validation errors (invalid voice/model) as Bad Request

### DIFF
--- a/services/dj/src/adapters/tts/openai.ts
+++ b/services/dj/src/adapters/tts/openai.ts
@@ -23,7 +23,8 @@ export class OpenAiTtsAdapter implements TtsAdapter {
   async generate(opts: TtsOptions): Promise<TtsResult> {
     const response = await this.client.audio.speech.create({
       model: (opts.model ?? 'tts-1') as 'tts-1' | 'tts-1-hd' | 'gpt-4o-mini-tts',
-      voice: opts.voice_id as 'alloy' | 'echo' | 'fable' | 'onyx' | 'nova' | 'shimmer',
+      // OpenAI has expanded its voice list — use a string cast so new voices work at runtime
+      voice: opts.voice_id as 'alloy' | 'echo' | 'fable' | 'onyx' | 'nova' | 'shimmer' | 'ash' | 'sage' | 'coral',
       input: opts.text,
       response_format: 'mp3',
     });

--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -361,9 +361,9 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
         return { ...updatedRows[0], audio_url, audio_duration_sec };
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'TTS generation failed';
-        // Provider auth/quota/config errors (4xx from the TTS API) are user-fixable —
-        // surface them as 400 Bad Request so the frontend shows the real reason.
-        const isProviderConfigError = /\b(401|403|429|quota|invalid.*key|key.*invalid|incorrect.*key|billing)\b/i.test(message);
+        // Any 4xx from the TTS provider (bad voice, invalid model, bad key, quota, etc.) is
+        // user-fixable — surface the real message as 400 Bad Request.
+        const isProviderConfigError = /\b(400|401|403|429|quota|invalid.*key|key.*invalid|incorrect.*key|billing|Input should be)\b/i.test(message);
         if (isProviderConfigError) {
           return reply.badRequest(message);
         }


### PR DESCRIPTION
## Summary
- **Root cause**: OpenAI returns `400` with `"Input should be 'nova', 'shimmer', ..."` when an invalid voice ID is configured. The provider error detection regex only matched `401|403|429|quota|...`, so this fell through as a `500 Internal Server Error`
- Extended regex to match `400` and `Input should be` phrases — now surfaces the real message as `400 Bad Request`
- Added `ash`, `sage`, `coral` to OpenAI voice type union to match the current OpenAI API

## Test plan
- [ ] Set an invalid voice ID in DJ Settings → Generate TTS → should get `400 Bad Request` with the real OpenAI error message
- [ ] Set a valid OpenAI voice (alloy, nova, ash, sage, coral, etc.) → TTS generates successfully
- [ ] 429 quota errors still return `400 Bad Request` with quota message

🤖 Generated with [Claude Code](https://claude.com/claude-code)