### PR TITLE
arch(station): Program as higher-tier entity — programs + episodes (#210)

### DIFF
--- a/frontend/src/app/programs/[id]/episodes/page.tsx
+++ b/frontend/src/app/programs/[id]/episodes/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentUser } from '@/lib/auth';
+import { api } from '@/lib/api';
+
+interface Program { id: string; name: string; }
+interface Episode {
+  id: string; program_id: string; air_date: string;
+  playlist_id: string | null; dj_script_id: string | null; manifest_id: string | null;
+  status: 'draft' | 'generating' | 'ready' | 'approved' | 'aired'; notes: string | null;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: 'bg-gray-700 text-gray-300', generating: 'bg-yellow-900 text-yellow-300',
+  ready: 'bg-blue-900 text-blue-300', approved: 'bg-green-900 text-green-300', aired: 'bg-purple-900 text-purple-300',
+};
+
+export default function EpisodesPage() {
+  const router = useRouter();
+  const { id: programId } = useParams<{ id: string }>();
+  const stationId = useSearchParams().get('station_id') ?? '';
+
+  const [program, setProgram] = useState<Program | null>(null);
+  const [episodes, setEpisodes] = useState<Episode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showForm, setShowForm] = useState(false);
+  const [newAirDate, setNewAirDate] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (!getCurrentUser()) { router.push('/login'); return; }
+    Promise.all([
+      api.get<Program>(`/api/v1/stations/${stationId}/programs/${programId}`),
+      api.get<Episode[]>(`/api/v1/stations/${stationId}/programs/${programId}/episodes`),
+    ]).then(([prog, eps]) => { setProgram(prog); setEpisodes(eps); })
+      .catch(() => setError('Failed to load episodes'))
+      .finally(() => setLoading(false));
+  }, [router, stationId, programId]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newAirDate) { setError('Air date required'); return; }
+    setCreating(true); setError('');
+    try {
+      const ep = await api.post<Episode>(
+        `/api/v1/stations/${stationId}/programs/${programId}/episodes`, { air_date: newAirDate },
+      );
+      setEpisodes((prev) => [ep, ...prev]);
+      setShowForm(false); setNewAirDate('');
+    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Failed'); }
+    finally { setCreating(false); }
+  }
+
+  if (loading) return <div className="p-8 text-gray-400">Loading…</div>;
+  if (!program) return <div className="p-8 text-gray-400">Program not found.</div>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div>
+        <Link href="/programs" className="text-gray-500 hover:text-gray-300 text-sm">← Programs</Link>
+        <div className="flex items-center justify-between mt-2">
+          <div>
+            <h1 className="text-2xl font-bold text-white">{program.name}</h1>
+            <p className="text-gray-400 text-sm mt-1">Episode history and schedule</p>
+          </div>
+          <button onClick={() => setShowForm(true)}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded font-medium">
+            + New Episode
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+
+      {showForm && (
+        <form onSubmit={handleCreate} className="bg-gray-800 rounded-lg p-5 space-y-4 border border-gray-700">
+          <h2 className="text-lg font-semibold text-white">New Episode</h2>
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Air Date *</label>
+            <input type="date" value={newAirDate} onChange={(e) => setNewAirDate(e.target.value)}
+              className="bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white" required />
+          </div>
+          <div className="flex gap-3">
+            <button type="submit" disabled={creating}
+              className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-2 rounded font-medium">
+              {creating ? 'Creating…' : 'Create Episode'}
+            </button>
+            <button type="button" onClick={() => setShowForm(false)} className="text-gray-400 hover:text-white px-4 py-2 rounded">
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {episodes.length === 0 ? (
+        <div className="text-center py-16 text-gray-500">
+          <p className="text-lg mb-1">No episodes yet</p>
+          <p className="text-sm">Create an episode to link a playlist and DJ script for a broadcast date.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {episodes.map((ep) => (
+            <div key={ep.id} className="bg-gray-800 rounded-lg p-4 flex items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-3">
+                  <span className="text-white font-medium">{ep.air_date}</span>
+                  <span className={`text-xs px-2 py-0.5 rounded capitalize ${STATUS_COLORS[ep.status] ?? 'bg-gray-700 text-gray-300'}`}>
+                    {ep.status}
+                  </span>
+                </div>
+                {ep.notes && <p className="text-gray-400 text-xs mt-1">{ep.notes}</p>}
+              </div>
+              <div className="flex items-center gap-3 text-sm shrink-0">
+                {ep.playlist_id && (
+                  <Link href={`/playlists/${ep.playlist_id}`} className="text-blue-400 hover:text-blue-300">Playlist</Link>
+                )}
+                {ep.dj_script_id && ep.playlist_id && (
+                  <Link href={`/playlists/${ep.playlist_id}?tab=dj`} className="text-purple-400 hover:text-purple-300">DJ Script</Link>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/programs/page.tsx
+++ b/frontend/src/app/programs/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentUser } from '@/lib/auth';
+import { api } from '@/lib/api';
+
+interface Station { id: string; name: string; }
+interface Program {
+  id: string; station_id: string; name: string; description: string | null;
+  air_days: string[]; start_time: string | null; end_time: string | null; is_active: boolean;
+}
+
+const DAY_LABELS: Record<string, string> = {
+  mon: 'Mon', tue: 'Tue', wed: 'Wed', thu: 'Thu', fri: 'Fri', sat: 'Sat', sun: 'Sun',
+};
+const ALL_DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+interface FormState {
+  name: string; description: string; air_days: string[];
+  start_time: string; end_time: string; is_active: boolean;
+}
+const EMPTY: FormState = { name: '', description: '', air_days: [], start_time: '', end_time: '', is_active: true };
+
+export default function ProgramsPage() {
+  const router = useRouter();
+  const [stations, setStations] = useState<Station[]>([]);
+  const [stationId, setStationId] = useState('');
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!getCurrentUser()) { router.push('/login'); return; }
+    api.get<Station[]>('/api/v1/stations').then((d) => {
+      setStations(d);
+      if (d.length > 0) setStationId(d[0].id);
+    }).catch(() => setError('Failed to load stations')).finally(() => setLoading(false));
+  }, [router]);
+
+  useEffect(() => {
+    if (!stationId) return;
+    api.get<Program[]>(`/api/v1/stations/${stationId}/programs`).then(setPrograms).catch(() => setPrograms([]));
+  }, [stationId]);
+
+  function openCreate() { setEditingId(null); setForm(EMPTY); setShowForm(true); setError(''); }
+
+  function openEdit(p: Program) {
+    setEditingId(p.id);
+    setForm({ name: p.name, description: p.description ?? '', air_days: p.air_days ?? [],
+               start_time: p.start_time ?? '', end_time: p.end_time ?? '', is_active: p.is_active });
+    setShowForm(true); setError('');
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.name.trim()) { setError('Name is required'); return; }
+    setSaving(true); setError('');
+    const payload = {
+      name: form.name.trim(), description: form.description.trim() || undefined,
+      air_days: form.air_days, start_time: form.start_time || undefined,
+      end_time: form.end_time || undefined, is_active: form.is_active,
+    };
+    try {
+      if (editingId) {
+        const u = await api.put<Program>(`/api/v1/stations/${stationId}/programs/${editingId}`, payload);
+        setPrograms((p) => p.map((x) => x.id === editingId ? u : x));
+      } else {
+        const c = await api.post<Program>(`/api/v1/stations/${stationId}/programs`, payload);
+        setPrograms((p) => [...p, c]);
+      }
+      setShowForm(false);
+    } catch (err: unknown) { setError(err instanceof Error ? err.message : 'Save failed'); }
+    finally { setSaving(false); }
+  }
+
+  async function handleDelete(id: string, name: string) {
+    if (!confirm(`Delete program "${name}"?`)) return;
+    try {
+      await api.delete(`/api/v1/stations/${stationId}/programs/${id}`);
+      setPrograms((p) => p.filter((x) => x.id !== id));
+    } catch { setError('Failed to delete'); }
+  }
+
+  if (loading) return <div className="p-8 text-gray-400">Loading…</div>;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Programs</h1>
+          <p className="text-gray-400 text-sm mt-1">Manage recurring shows and their episode schedules.</p>
+        </div>
+        <button onClick={openCreate} className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded font-medium">
+          + New Program
+        </button>
+      </div>
+
+      {stations.length > 1 && (
+        <select value={stationId} onChange={(e) => setStationId(e.target.value)}
+          className="bg-gray-800 border border-gray-600 rounded px-3 py-2 text-white">
+          {stations.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+      )}
+
+      {error && !showForm && <p className="text-red-400 text-sm">{error}</p>}
+
+      {showForm && (
+        <form onSubmit={handleSave} className="bg-gray-800 rounded-lg p-6 space-y-4 border border-gray-700">
+          <h2 className="text-lg font-semibold text-white">{editingId ? 'Edit Program' : 'New Program'}</h2>
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Name *</label>
+            <input type="text" value={form.name} onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              placeholder="e.g. Morning Rush"
+              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white" required />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-300 mb-1">Description</label>
+            <input type="text" value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white" />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-300 mb-2">Air Days</label>
+            <div className="flex flex-wrap gap-2">
+              {ALL_DAYS.map((day) => (
+                <button key={day} type="button"
+                  onClick={() => setForm((f) => ({ ...f, air_days: f.air_days.includes(day) ? f.air_days.filter((d) => d !== day) : [...f.air_days, day] }))}
+                  className={`px-3 py-1 rounded text-sm font-medium ${form.air_days.includes(day) ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}`}>
+                  {DAY_LABELS[day]}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">Start Time</label>
+              <input type="time" value={form.start_time} onChange={(e) => setForm((f) => ({ ...f, start_time: e.target.value }))}
+                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white" />
+            </div>
+            <div>
+              <label className="block text-sm text-gray-300 mb-1">End Time</label>
+              <input type="time" value={form.end_time} onChange={(e) => setForm((f) => ({ ...f, end_time: e.target.value }))}
+                className="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white" />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <input type="checkbox" id="active" checked={form.is_active}
+              onChange={(e) => setForm((f) => ({ ...f, is_active: e.target.checked }))} className="rounded" />
+            <label htmlFor="active" className="text-sm text-gray-300">Active</label>
+          </div>
+          <div className="flex gap-3">
+            <button type="submit" disabled={saving}
+              className="bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white px-4 py-2 rounded font-medium">
+              {saving ? 'Saving…' : (editingId ? 'Save Changes' : 'Create Program')}
+            </button>
+            <button type="button" onClick={() => setShowForm(false)} className="text-gray-400 hover:text-white px-4 py-2 rounded">
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {programs.length === 0 ? (
+        <div className="text-center py-16 text-gray-500">
+          <p className="text-lg mb-1">No programs yet</p>
+          <p className="text-sm">Create a program to organize episodes and show schedules.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {programs.map((p) => (
+            <div key={p.id} className="bg-gray-800 rounded-lg p-5 flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h3 className="text-white font-semibold">{p.name}</h3>
+                  {!p.is_active && <span className="text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded">Inactive</span>}
+                </div>
+                {p.description && <p className="text-gray-400 text-sm mb-1">{p.description}</p>}
+                <div className="text-xs text-gray-500 space-x-3">
+                  {p.air_days?.length > 0 && <span>{p.air_days.map((d) => DAY_LABELS[d] ?? d).join(', ')}</span>}
+                  {p.start_time && p.end_time && <span>{p.start_time} – {p.end_time}</span>}
+                </div>
+              </div>
+              <div className="flex items-center gap-3 shrink-0 text-sm">
+                <Link href={`/programs/${p.id}/episodes?station_id=${stationId}`}
+                  className="text-blue-400 hover:text-blue-300">Episodes</Link>
+                <button onClick={() => openEdit(p)} className="text-gray-400 hover:text-white">Edit</button>
+                <button onClick={() => handleDelete(p.id, p.name)} className="text-gray-500 hover:text-red-400">Delete</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/station/src/index.ts
+++ b/services/station/src/index.ts
@@ -6,6 +6,7 @@ import { companyRoutes } from './routes/companies';
 import { stationRoutes } from './routes/stations';
 import { stationSettingsRoutes } from './routes/stationSettings';
 import { userRoutes } from './routes/users';
+import { programRoutes } from './routes/programs';
 
 const app = Fastify({
   logger: {
@@ -25,6 +26,7 @@ app.register(companyRoutes,        { prefix: '/api/v1' });
 app.register(stationRoutes,        { prefix: '/api/v1' });
 app.register(stationSettingsRoutes, { prefix: '/api/v1' });
 app.register(userRoutes,           { prefix: '/api/v1' });
+app.register(programRoutes,        { prefix: '/api/v1' });
 
 app.setErrorHandler((err: FastifyError, _req, reply) => {
   app.log.error(err);

--- a/services/station/src/routes/programs.ts
+++ b/services/station/src/routes/programs.ts
@@ -1,0 +1,189 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticate, requirePermission, requireStationAccess } from '@playgen/middleware';
+import { getPool } from '../db';
+import type {
+  Program,
+  ProgramEpisode,
+  CreateProgramRequest,
+  CreateEpisodeRequest,
+} from '@playgen/types';
+
+export async function programRoutes(app: FastifyInstance): Promise<void> {
+  app.addHook('onRequest', authenticate);
+
+  // ── Programs ──────────────────────────────────────────────────────────────
+
+  app.get<{ Params: { station_id: string } }>(
+    '/stations/:station_id/programs',
+    { onRequest: [requirePermission('station:read'), requireStationAccess()] },
+    async (req) => {
+      const { station_id } = req.params;
+      const { rows } = await getPool().query<Program>(
+        `SELECT * FROM programs WHERE station_id = $1 ORDER BY name`,
+        [station_id],
+      );
+      return rows;
+    },
+  );
+
+  app.get<{ Params: { station_id: string; id: string } }>(
+    '/stations/:station_id/programs/:id',
+    { onRequest: [requirePermission('station:read'), requireStationAccess()] },
+    async (req, reply) => {
+      const { id, station_id } = req.params;
+      const { rows } = await getPool().query<Program>(
+        `SELECT * FROM programs WHERE id = $1 AND station_id = $2`,
+        [id, station_id],
+      );
+      if (!rows[0]) return reply.notFound('Program not found');
+      return rows[0];
+    },
+  );
+
+  app.post<{ Params: { station_id: string }; Body: CreateProgramRequest }>(
+    '/stations/:station_id/programs',
+    { onRequest: [requirePermission('station:write'), requireStationAccess()] },
+    async (req, reply) => {
+      const { station_id } = req.params;
+      const { name, description, air_days, start_time, end_time, dj_profile_id, format_config, is_active } = req.body;
+      if (!name?.trim()) return reply.badRequest('name is required');
+      const { rows } = await getPool().query<Program>(
+        `INSERT INTO programs (station_id, name, description, air_days, start_time, end_time, dj_profile_id, format_config, is_active)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *`,
+        [station_id, name.trim(), description ?? null, air_days ?? [], start_time ?? null, end_time ?? null,
+         dj_profile_id ?? null, format_config ? JSON.stringify(format_config) : null, is_active ?? true],
+      );
+      return reply.code(201).send(rows[0]);
+    },
+  );
+
+  app.put<{ Params: { station_id: string; id: string }; Body: Partial<CreateProgramRequest> }>(
+    '/stations/:station_id/programs/:id',
+    { onRequest: [requirePermission('station:write'), requireStationAccess()] },
+    async (req, reply) => {
+      const { id, station_id } = req.params;
+      const updates = req.body;
+      const fields: string[] = [];
+      const values: unknown[] = [];
+      let idx = 1;
+      const allowed: Array<keyof CreateProgramRequest> = [
+        'name', 'description', 'air_days', 'start_time', 'end_time', 'dj_profile_id', 'format_config', 'is_active',
+      ];
+      for (const key of allowed) {
+        if (key in updates) {
+          fields.push(`${key} = $${idx++}`);
+          values.push(key === 'format_config' && updates[key] ? JSON.stringify(updates[key]) : updates[key] ?? null);
+        }
+      }
+      if (fields.length === 0) return reply.badRequest('No fields to update');
+      fields.push(`updated_at = NOW()`);
+      values.push(id, station_id);
+      const { rows } = await getPool().query<Program>(
+        `UPDATE programs SET ${fields.join(', ')} WHERE id = $${idx} AND station_id = $${idx + 1} RETURNING *`,
+        values,
+      );
+      if (!rows[0]) return reply.notFound('Program not found');
+      return rows[0];
+    },
+  );
+
+  app.delete<{ Params: { station_id: string; id: string } }>(
+    '/stations/:station_id/programs/:id',
+    { onRequest: [requirePermission('station:write'), requireStationAccess()] },
+    async (req, reply) => {
+      const { id, station_id } = req.params;
+      const { rowCount } = await getPool().query(
+        `DELETE FROM programs WHERE id = $1 AND station_id = $2`,
+        [id, station_id],
+      );
+      if (!rowCount) return reply.notFound('Program not found');
+      return reply.code(204).send();
+    },
+  );
+
+  // ── Episodes ──────────────────────────────────────────────────────────────
+
+  app.get<{ Params: { station_id: string; program_id: string }; Querystring: { limit?: string } }>(
+    '/stations/:station_id/programs/:program_id/episodes',
+    { onRequest: [requirePermission('station:read'), requireStationAccess()] },
+    async (req, reply) => {
+      const { program_id, station_id } = req.params;
+      const limit = Math.min(parseInt(req.query.limit ?? '50', 10) || 50, 200);
+      const { rows: prog } = await getPool().query(
+        `SELECT id FROM programs WHERE id = $1 AND station_id = $2`, [program_id, station_id],
+      );
+      if (!prog[0]) return reply.notFound('Program not found');
+      const { rows } = await getPool().query<ProgramEpisode>(
+        `SELECT * FROM program_episodes WHERE program_id = $1 ORDER BY air_date DESC LIMIT $2`,
+        [program_id, limit],
+      );
+      return rows;
+    },
+  );
+
+  app.get<{ Params: { station_id: string; program_id: string; id: string } }>(
+    '/stations/:station_id/programs/:program_id/episodes/:id',
+    { onRequest: [requirePermission('station:read'), requireStationAccess()] },
+    async (req, reply) => {
+      const { program_id, id, station_id } = req.params;
+      const { rows: prog } = await getPool().query(
+        `SELECT id FROM programs WHERE id = $1 AND station_id = $2`, [program_id, station_id],
+      );
+      if (!prog[0]) return reply.notFound('Program not found');
+      const { rows } = await getPool().query<ProgramEpisode>(
+        `SELECT * FROM program_episodes WHERE id = $1 AND program_id = $2`, [id, program_id],
+      );
+      if (!rows[0]) return reply.notFound('Episode not found');
+      return rows[0];
+    },
+  );
+
+  app.post<{ Params: { station_id: string; program_id: string }; Body: CreateEpisodeRequest }>(
+    '/stations/:station_id/programs/:program_id/episodes',
+    { onRequest: [requirePermission('station:write'), requireStationAccess()] },
+    async (req, reply) => {
+      const { program_id, station_id } = req.params;
+      const { air_date, playlist_id, dj_script_id, notes } = req.body;
+      if (!air_date) return reply.badRequest('air_date is required');
+      const { rows: prog } = await getPool().query(
+        `SELECT id FROM programs WHERE id = $1 AND station_id = $2`, [program_id, station_id],
+      );
+      if (!prog[0]) return reply.notFound('Program not found');
+      const { rows } = await getPool().query<ProgramEpisode>(
+        `INSERT INTO program_episodes (program_id, air_date, playlist_id, dj_script_id, notes)
+         VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+        [program_id, air_date, playlist_id ?? null, dj_script_id ?? null, notes ?? null],
+      );
+      return reply.code(201).send(rows[0]);
+    },
+  );
+
+  app.patch<{
+    Params: { station_id: string; program_id: string; id: string };
+    Body: { status?: string; playlist_id?: string; dj_script_id?: string; manifest_id?: string; notes?: string };
+  }>(
+    '/stations/:station_id/programs/:program_id/episodes/:id',
+    { onRequest: [requirePermission('station:write'), requireStationAccess()] },
+    async (req, reply) => {
+      const { program_id, id, station_id } = req.params;
+      const { status, playlist_id, dj_script_id, manifest_id, notes } = req.body;
+      const { rows: prog } = await getPool().query(
+        `SELECT id FROM programs WHERE id = $1 AND station_id = $2`, [program_id, station_id],
+      );
+      if (!prog[0]) return reply.notFound('Program not found');
+      const { rows } = await getPool().query<ProgramEpisode>(
+        `UPDATE program_episodes
+         SET status       = COALESCE($3::episode_status, status),
+             playlist_id  = COALESCE($4, playlist_id),
+             dj_script_id = COALESCE($5, dj_script_id),
+             manifest_id  = COALESCE($6, manifest_id),
+             notes        = COALESCE($7, notes),
+             updated_at   = NOW()
+         WHERE id = $1 AND program_id = $2 RETURNING *`,
+        [id, program_id, status ?? null, playlist_id ?? null, dj_script_id ?? null, manifest_id ?? null, notes ?? null],
+      );
+      if (!rows[0]) return reply.notFound('Episode not found');
+      return rows[0];
+    },
+  );
+}

--- a/shared/db/src/migrations/034_create_programs.sql
+++ b/shared/db/src/migrations/034_create_programs.sql
@@ -1,0 +1,20 @@
+-- Create programs table (issue #210: Program as higher-tier entity)
+-- A Program is a recurring named radio show (e.g. "Morning Rush", "Afternoon Drive")
+
+CREATE TABLE IF NOT EXISTS programs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    station_id      UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    name            VARCHAR(150) NOT NULL,
+    description     TEXT,
+    air_days        TEXT[] NOT NULL DEFAULT '{}',
+    start_time      TIME,
+    end_time        TIME,
+    dj_profile_id   UUID REFERENCES dj_profiles(id) ON DELETE SET NULL,
+    format_config   JSONB,
+    is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_programs_station        ON programs(station_id);
+CREATE INDEX IF NOT EXISTS idx_programs_station_active ON programs(station_id, is_active);

--- a/shared/db/src/migrations/035_create_program_episodes.sql
+++ b/shared/db/src/migrations/035_create_program_episodes.sql
@@ -1,0 +1,63 @@
+-- Create program_episodes table (issue #210: Program as higher-tier entity)
+-- An Episode is a single air-date instance of a Program.
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'episode_status') THEN
+    CREATE TYPE episode_status AS ENUM ('draft', 'generating', 'ready', 'approved', 'aired');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS program_episodes (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    program_id      UUID NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+    air_date        DATE NOT NULL,
+    playlist_id     UUID REFERENCES playlists(id) ON DELETE SET NULL,
+    dj_script_id    UUID REFERENCES dj_scripts(id) ON DELETE SET NULL,
+    manifest_id     UUID REFERENCES dj_show_manifests(id) ON DELETE SET NULL,
+    status          episode_status NOT NULL DEFAULT 'draft',
+    notes           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (program_id, air_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_episodes_program  ON program_episodes(program_id);
+CREATE INDEX IF NOT EXISTS idx_program_episodes_date     ON program_episodes(program_id, air_date DESC);
+CREATE INDEX IF NOT EXISTS idx_program_episodes_playlist ON program_episodes(playlist_id) WHERE playlist_id IS NOT NULL;
+
+-- Back-fill: create a default "Unassigned" program for each station and link
+-- existing playlists to episodes under that program.
+DO $$
+DECLARE
+    rec RECORD;
+    default_program_id UUID;
+BEGIN
+    FOR rec IN SELECT DISTINCT station_id FROM playlists LOOP
+        SELECT id INTO default_program_id
+        FROM programs
+        WHERE station_id = rec.station_id AND name = 'Unassigned';
+
+        IF default_program_id IS NULL THEN
+            INSERT INTO programs (station_id, name, description, is_active)
+            VALUES (rec.station_id, 'Unassigned', 'Auto-created default program for pre-Program playlists', FALSE)
+            RETURNING id INTO default_program_id;
+        END IF;
+
+        INSERT INTO program_episodes (program_id, air_date, playlist_id, dj_script_id, status)
+        SELECT
+            default_program_id,
+            p.date,
+            p.id,
+            ds.id,
+            CASE
+                WHEN ds.review_status IN ('approved', 'auto_approved') THEN 'approved'::episode_status
+                ELSE 'ready'::episode_status
+            END
+        FROM playlists p
+        LEFT JOIN dj_scripts ds ON ds.playlist_id = p.id
+        WHERE p.station_id = rec.station_id
+          AND NOT EXISTS (SELECT 1 FROM program_episodes pe WHERE pe.playlist_id = p.id)
+        ON CONFLICT (program_id, air_date) DO NOTHING;
+    END LOOP;
+END
+$$;

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -256,6 +256,13 @@ export type DjSegmentType =
   | 'time_check'
   | 'weather_tease'
   | 'ad_break';
+/** Headline shape returned by news data providers (used by current_events segments). */
+export interface NewsHeadline {
+  title: string;
+  description?: string;
+  source?: string;
+}
+
 export type DjReviewStatus = 'pending_review' | 'approved' | 'rejected' | 'auto_approved';
 export type DjSegmentReviewStatus = 'pending' | 'approved' | 'edited' | 'rejected';
 export type ManifestStatus = 'building' | 'ready' | 'failed';
@@ -396,6 +403,57 @@ export interface StationSetting {
   is_secret: boolean;
   created_at: string;
   updated_at: string;
+}
+
+// ─── Programs & Episodes (issue #210) ─────────────────────────────────────────
+
+export type ProgramAirDay = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+export type EpisodeStatus = 'draft' | 'generating' | 'ready' | 'approved' | 'aired';
+
+export interface Program {
+  id: string;
+  station_id: string;
+  name: string;
+  description: string | null;
+  air_days: ProgramAirDay[];
+  start_time: string | null;
+  end_time: string | null;
+  dj_profile_id: string | null;
+  format_config: Record<string, unknown> | null;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ProgramEpisode {
+  id: string;
+  program_id: string;
+  air_date: string;
+  playlist_id: string | null;
+  dj_script_id: string | null;
+  manifest_id: string | null;
+  status: EpisodeStatus;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateProgramRequest {
+  name: string;
+  description?: string;
+  air_days?: ProgramAirDay[];
+  start_time?: string;
+  end_time?: string;
+  dj_profile_id?: string;
+  format_config?: Record<string, unknown>;
+  is_active?: boolean;
+}
+
+export interface CreateEpisodeRequest {
+  air_date: string;
+  playlist_id?: string;
+  dj_script_id?: string;
+  notes?: string;
 }
 
 // ─── API Responses ────────────────────────────────────────────────────────────

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -14,6 +14,7 @@ Before starting any task, an agent MUST:
 
 ## Active Work
 - [ ] Fix DJ Script generation INTERNAL_ERROR — missing API key validation + unmasked LLM errors (issue #183, fix/issue-183) | @claude-code | 2026-04-05
+- [ ] arch: Program as higher-tier entity — programs + program_episodes (issue #210, feat/issue-210-program-entity) | @claude-code | 2026-04-06 | Migration: 034-035
 
 ## Recently Completed
 - [x] Google OAuth login (issue #200, feat/issue-200-google-oauth) | @claude-code | 2026-04-05


### PR DESCRIPTION
## Summary

Implements the **additive foundation** for the Program > Episode > Content architecture (issue #210). This is a non-breaking, additive migration with no changes to existing tables.

### Database Changes
- **Migration 034**: `programs` table — recurring show definitions (name, air_days, start/end time, dj_profile_id, format_config JSONB)
- **Migration 035**: `program_episodes` table — single air-date instances linking playlist_id, dj_script_id, manifest_id; `episode_status` enum (draft → generating → ready → approved → aired)
- **Back-fill**: creates an "Unassigned" default program per station and links all existing playlists/scripts into episodes automatically

### API (Station Service)
- Program CRUD: `GET/POST/PUT/DELETE /api/v1/stations/:station_id/programs`
- Episode CRUD: `GET/POST /api/v1/stations/:station_id/programs/:program_id/episodes`
- Episode update: `PATCH /api/v1/stations/:station_id/programs/:program_id/episodes/:id`

### Shared Types
- `Program`, `ProgramEpisode`, `EpisodeStatus`, `ProgramAirDay`
- `CreateProgramRequest`, `CreateEpisodeRequest`
- `NewsHeadline` (forward-declared for #208 current_events adapter compatibility)

### Frontend
- `/programs` — program list with create/edit/delete, air-days multi-select, time slots
- `/programs/[id]/episodes` — episode history with status badges and playlist/DJ links

> **Note**: DJ script generation tied to episodes and episode-aware manifest builder are planned as follow-up PRs (#210 phase 2). This PR is additive only — zero regression risk.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — 0 errors (1 pre-existing warning from main)
- [x] `pnpm run test:unit` — all 22 station + 72 DJ + other tests pass
- [ ] Create a program via `POST /api/v1/stations/:id/programs`, verify it persists
- [ ] Create an episode linking to an existing playlist, verify status transitions
- [ ] Visit `/programs` and verify CRUD UI works end-to-end
- [ ] Run migration on dev DB, verify back-fill creates expected episodes

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)