### PR TITLE
feat(station): Station Details page — locale, callsign, social handles, and system metadata

### DIFF
--- a/frontend/src/app/stations/[id]/details/page.tsx
+++ b/frontend/src/app/stations/[id]/details/page.tsx
@@ -1,0 +1,632 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
+import { api } from '@/lib/api';
+import type { ApiError } from '@/lib/api';
+
+type BroadcastType = 'fm' | 'am' | 'online' | 'podcast' | 'dab';
+
+interface StationDetails {
+  id: string;
+  company_id: string;
+  name: string;
+  timezone: string;
+  // Identity
+  callsign: string | null;
+  tagline: string | null;
+  frequency: string | null;
+  broadcast_type: BroadcastType | null;
+  // Locale
+  city: string | null;
+  province: string | null;
+  country: string | null;
+  locale_code: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  // Social media
+  facebook_page_url: string | null;
+  twitter_handle: string | null;
+  instagram_handle: string | null;
+  youtube_channel_url: string | null;
+  // Branding
+  logo_url: string | null;
+  primary_color: string | null;
+  secondary_color: string | null;
+  website_url: string | null;
+}
+
+interface FormState {
+  // Identity
+  callsign: string;
+  tagline: string;
+  frequency: string;
+  broadcast_type: BroadcastType;
+  // Locale
+  city: string;
+  province: string;
+  country: string;
+  timezone: string;
+  locale_code: string;
+  latitude: string;
+  longitude: string;
+  // Social media
+  facebook_page_url: string;
+  twitter_handle: string;
+  instagram_handle: string;
+  youtube_channel_url: string;
+  // Branding
+  logo_url: string;
+  website_url: string;
+  primary_color: string;
+  secondary_color: string;
+}
+
+const EMPTY_FORM: FormState = {
+  callsign: '',
+  tagline: '',
+  frequency: '',
+  broadcast_type: 'fm',
+  city: '',
+  province: '',
+  country: '',
+  timezone: '',
+  locale_code: '',
+  latitude: '',
+  longitude: '',
+  facebook_page_url: '',
+  twitter_handle: '',
+  instagram_handle: '',
+  youtube_channel_url: '',
+  logo_url: '',
+  website_url: '',
+  primary_color: '#7c3aed',
+  secondary_color: '#a78bfa',
+};
+
+const BROADCAST_TYPE_OPTIONS: Array<{ value: BroadcastType; label: string }> = [
+  { value: 'fm', label: 'FM' },
+  { value: 'am', label: 'AM' },
+  { value: 'online', label: 'Online / Streaming' },
+  { value: 'podcast', label: 'Podcast' },
+  { value: 'dab', label: 'DAB / Digital' },
+];
+
+function stationToForm(station: StationDetails): FormState {
+  return {
+    callsign: station.callsign ?? '',
+    tagline: station.tagline ?? '',
+    frequency: station.frequency ?? '',
+    broadcast_type: station.broadcast_type ?? 'fm',
+    city: station.city ?? '',
+    province: station.province ?? '',
+    country: station.country ?? '',
+    timezone: station.timezone ?? '',
+    locale_code: station.locale_code ?? '',
+    latitude: station.latitude != null ? String(station.latitude) : '',
+    longitude: station.longitude != null ? String(station.longitude) : '',
+    facebook_page_url: station.facebook_page_url ?? '',
+    twitter_handle: station.twitter_handle ?? '',
+    instagram_handle: station.instagram_handle ?? '',
+    youtube_channel_url: station.youtube_channel_url ?? '',
+    logo_url: station.logo_url ?? '',
+    website_url: station.website_url ?? '',
+    primary_color: station.primary_color ?? '#7c3aed',
+    secondary_color: station.secondary_color ?? '#a78bfa',
+  };
+}
+
+function formToPayload(form: FormState): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    callsign: form.callsign || null,
+    tagline: form.tagline || null,
+    frequency: form.frequency || null,
+    broadcast_type: form.broadcast_type || null,
+    city: form.city || null,
+    province: form.province || null,
+    country: form.country || null,
+    timezone: form.timezone || null,
+    locale_code: form.locale_code || null,
+    latitude: form.latitude !== '' ? parseFloat(form.latitude) : null,
+    longitude: form.longitude !== '' ? parseFloat(form.longitude) : null,
+    facebook_page_url: form.facebook_page_url || null,
+    twitter_handle: form.twitter_handle || null,
+    instagram_handle: form.instagram_handle || null,
+    youtube_channel_url: form.youtube_channel_url || null,
+    logo_url: form.logo_url || null,
+    website_url: form.website_url || null,
+    primary_color: /^#[0-9A-Fa-f]{6}$/.test(form.primary_color) ? form.primary_color : null,
+    secondary_color: /^#[0-9A-Fa-f]{6}$/.test(form.secondary_color) ? form.secondary_color : null,
+  };
+  // Remove keys where timezone is empty (don't overwrite with null if not changed)
+  if (payload.timezone === null) delete payload.timezone;
+  return payload;
+}
+
+export default function StationDetailsPage() {
+  const params = useParams<{ id: string }>();
+  const stationId = params.id;
+  const router = useRouter();
+  const currentUser = getCurrentUser();
+
+  const [station, setStation] = useState<StationDetails | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!currentUser) {
+      router.replace('/login');
+      return;
+    }
+    fetchStation();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stationId]);
+
+  async function fetchStation() {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await api.get<StationDetails>(`/api/v1/stations/${stationId}`);
+      setStation(data);
+      setForm(stationToForm(data));
+    } catch (err: unknown) {
+      setLoadError((err as ApiError).message ?? 'Failed to load station');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    setSaveError(null);
+    setSaveSuccess(false);
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      const updated = await api.put<StationDetails>(
+        `/api/v1/stations/${stationId}`,
+        formToPayload(form),
+      );
+      setStation(updated);
+      setForm(stationToForm(updated));
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch (err: unknown) {
+      setSaveError((err as ApiError).message ?? 'Failed to save station details');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!currentUser) return null;
+
+  return (
+    <div className="p-6 md:p-8 max-w-3xl">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-gray-500 hover:text-gray-300 text-sm"
+        >
+          ← Back
+        </button>
+        <h1 className="text-xl font-bold text-white">Station Details</h1>
+      </div>
+
+      {loadError && (
+        <div className="mb-4 rounded-md bg-red-900/30 border border-red-700/50 px-4 py-3">
+          <p className="text-sm text-red-400">{loadError}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="w-8 h-8 border-4 border-violet-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : (
+        <>
+          {/* Preview card */}
+          {station && (
+            <div
+              className="mb-6 rounded-xl border border-[#2a2a40] p-5 flex items-start gap-4"
+              style={{ background: form.primary_color ? `${form.primary_color}18` : undefined }}
+            >
+              {form.logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={form.logo_url}
+                  alt="Station logo"
+                  className="w-14 h-14 rounded-lg object-contain bg-[#16161f] border border-[#2a2a40]"
+                />
+              ) : (
+                <div
+                  className="w-14 h-14 rounded-lg flex items-center justify-center text-white font-bold text-lg shrink-0"
+                  style={{ background: form.primary_color ?? '#7c3aed' }}
+                >
+                  {form.callsign ? form.callsign.slice(0, 2).toUpperCase() : station.name.slice(0, 2).toUpperCase()}
+                </div>
+              )}
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-white font-semibold text-base">
+                    {form.callsign || station.name}
+                  </span>
+                  {form.frequency && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-violet-900/40 text-violet-300 border border-violet-700/40">
+                      {form.frequency} {form.broadcast_type?.toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                {form.tagline && (
+                  <p className="text-sm text-gray-400 mt-0.5 truncate">{form.tagline}</p>
+                )}
+                {(form.city || form.country) && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    {[form.city, form.country].filter(Boolean).join(', ')}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Identity */}
+            <section className="card p-5">
+              <h2 className="text-sm font-semibold text-violet-400 uppercase tracking-wider mb-4">
+                Identity
+              </h2>
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    label="Callsign"
+                    description="Station call letters (e.g. DWRR)"
+                  >
+                    <input
+                      type="text"
+                      value={form.callsign}
+                      onChange={(e) => setField('callsign', e.target.value)}
+                      maxLength={10}
+                      placeholder="e.g. DWRR"
+                      className="input w-full"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Frequency"
+                    description="Broadcast frequency (e.g. 97.9)"
+                  >
+                    <input
+                      type="text"
+                      value={form.frequency}
+                      onChange={(e) => setField('frequency', e.target.value)}
+                      maxLength={20}
+                      placeholder="e.g. 97.9"
+                      className="input w-full"
+                    />
+                  </FormField>
+                </div>
+                <FormField
+                  label="Tagline"
+                  description="Short slogan or description for the station"
+                >
+                  <input
+                    type="text"
+                    value={form.tagline}
+                    onChange={(e) => setField('tagline', e.target.value)}
+                    maxLength={255}
+                    placeholder="e.g. Manila's #1 Hit Music Station"
+                    className="input w-full"
+                  />
+                </FormField>
+                <FormField
+                  label="Broadcast Type"
+                  description="Medium through which this station broadcasts"
+                >
+                  <select
+                    value={form.broadcast_type}
+                    onChange={(e) => setField('broadcast_type', e.target.value as BroadcastType)}
+                    className="input w-full"
+                  >
+                    {BROADCAST_TYPE_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
+              </div>
+            </section>
+
+            {/* Locale */}
+            <section className="card p-5">
+              <h2 className="text-sm font-semibold text-violet-400 uppercase tracking-wider mb-4">
+                Locale
+              </h2>
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField label="City">
+                    <input
+                      type="text"
+                      value={form.city}
+                      onChange={(e) => setField('city', e.target.value)}
+                      maxLength={100}
+                      placeholder="e.g. Manila"
+                      className="input w-full"
+                    />
+                  </FormField>
+                  <FormField label="Province / State">
+                    <input
+                      type="text"
+                      value={form.province}
+                      onChange={(e) => setField('province', e.target.value)}
+                      maxLength={100}
+                      placeholder="e.g. Metro Manila"
+                      className="input w-full"
+                    />
+                  </FormField>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField label="Country">
+                    <input
+                      type="text"
+                      value={form.country}
+                      onChange={(e) => setField('country', e.target.value)}
+                      maxLength={100}
+                      placeholder="e.g. Philippines"
+                      className="input w-full"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Timezone"
+                    description="IANA timezone identifier"
+                  >
+                    <input
+                      type="text"
+                      value={form.timezone}
+                      onChange={(e) => setField('timezone', e.target.value)}
+                      maxLength={100}
+                      placeholder="Asia/Manila"
+                      className="input w-full"
+                    />
+                  </FormField>
+                </div>
+                <FormField
+                  label="Locale Code"
+                  description="BCP 47 locale tag (e.g. en-PH)"
+                >
+                  <input
+                    type="text"
+                    value={form.locale_code}
+                    onChange={(e) => setField('locale_code', e.target.value)}
+                    maxLength={20}
+                    placeholder="e.g. en-PH"
+                    className="input w-full"
+                  />
+                </FormField>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    label="Latitude"
+                    description="Decimal degrees, -90 to 90"
+                  >
+                    <input
+                      type="number"
+                      value={form.latitude}
+                      onChange={(e) => setField('latitude', e.target.value)}
+                      step="0.000001"
+                      min={-90}
+                      max={90}
+                      placeholder="e.g. 14.5995"
+                      className="input w-full"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Longitude"
+                    description="Decimal degrees, -180 to 180"
+                  >
+                    <input
+                      type="number"
+                      value={form.longitude}
+                      onChange={(e) => setField('longitude', e.target.value)}
+                      step="0.000001"
+                      min={-180}
+                      max={180}
+                      placeholder="e.g. 120.9842"
+                      className="input w-full"
+                    />
+                  </FormField>
+                </div>
+              </div>
+            </section>
+
+            {/* Social Media */}
+            <section className="card p-5">
+              <h2 className="text-sm font-semibold text-violet-400 uppercase tracking-wider mb-4">
+                Social Media
+              </h2>
+              <div className="space-y-4">
+                <FormField label="Facebook Page URL">
+                  <input
+                    type="text"
+                    value={form.facebook_page_url}
+                    onChange={(e) => setField('facebook_page_url', e.target.value)}
+                    maxLength={255}
+                    placeholder="https://facebook.com/yourstation"
+                    className="input w-full"
+                  />
+                </FormField>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField label="Twitter / X Handle">
+                    <div className="flex items-center">
+                      <span className="px-3 py-2 bg-[#13131a] border border-r-0 border-[#2a2a40] rounded-l-md text-gray-500 text-sm">@</span>
+                      <input
+                        type="text"
+                        value={form.twitter_handle}
+                        onChange={(e) => setField('twitter_handle', e.target.value.replace(/^@/, ''))}
+                        maxLength={100}
+                        placeholder="yourstation"
+                        className="input w-full rounded-l-none"
+                      />
+                    </div>
+                  </FormField>
+                  <FormField label="Instagram Handle">
+                    <div className="flex items-center">
+                      <span className="px-3 py-2 bg-[#13131a] border border-r-0 border-[#2a2a40] rounded-l-md text-gray-500 text-sm">@</span>
+                      <input
+                        type="text"
+                        value={form.instagram_handle}
+                        onChange={(e) => setField('instagram_handle', e.target.value.replace(/^@/, ''))}
+                        maxLength={100}
+                        placeholder="yourstation"
+                        className="input w-full rounded-l-none"
+                      />
+                    </div>
+                  </FormField>
+                </div>
+                <FormField label="YouTube Channel URL">
+                  <input
+                    type="text"
+                    value={form.youtube_channel_url}
+                    onChange={(e) => setField('youtube_channel_url', e.target.value)}
+                    maxLength={255}
+                    placeholder="https://youtube.com/@yourstation"
+                    className="input w-full"
+                  />
+                </FormField>
+              </div>
+            </section>
+
+            {/* Branding */}
+            <section className="card p-5">
+              <h2 className="text-sm font-semibold text-violet-400 uppercase tracking-wider mb-4">
+                Branding
+              </h2>
+              <div className="space-y-4">
+                <FormField
+                  label="Logo URL"
+                  description="Direct URL to the station logo image"
+                >
+                  <input
+                    type="text"
+                    value={form.logo_url}
+                    onChange={(e) => setField('logo_url', e.target.value)}
+                    maxLength={500}
+                    placeholder="https://example.com/logo.png"
+                    className="input w-full"
+                  />
+                </FormField>
+                <FormField
+                  label="Website URL"
+                  description="Station's main website"
+                >
+                  <input
+                    type="text"
+                    value={form.website_url}
+                    onChange={(e) => setField('website_url', e.target.value)}
+                    maxLength={255}
+                    placeholder="https://yourstation.com"
+                    className="input w-full"
+                  />
+                </FormField>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <FormField
+                    label="Primary Color"
+                    description="Main brand color (hex)"
+                  >
+                    <ColorInput
+                      value={form.primary_color}
+                      onChange={(v) => setField('primary_color', v)}
+                    />
+                  </FormField>
+                  <FormField
+                    label="Secondary Color"
+                    description="Accent brand color (hex)"
+                  >
+                    <ColorInput
+                      value={form.secondary_color}
+                      onChange={(v) => setField('secondary_color', v)}
+                    />
+                  </FormField>
+                </div>
+              </div>
+            </section>
+
+            {/* Save */}
+            <div className="flex items-center gap-4">
+              <button
+                type="submit"
+                disabled={saving}
+                className="btn-primary disabled:opacity-50"
+              >
+                {saving ? 'Saving…' : 'Save Details'}
+              </button>
+              {saveSuccess && (
+                <span className="text-sm text-green-400">Details saved.</span>
+              )}
+              {saveError && (
+                <span className="text-sm text-red-400">{saveError}</span>
+              )}
+            </div>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── FormField ────────────────────────────────────────────────────────────────
+
+interface FormFieldProps {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+function FormField({ label, description, children }: FormFieldProps) {
+  return (
+    <div>
+      <label className="block text-sm text-gray-300 mb-0.5 font-medium">{label}</label>
+      {description && <p className="text-xs text-gray-500 mb-1.5">{description}</p>}
+      {children}
+    </div>
+  );
+}
+
+// ─── ColorInput ───────────────────────────────────────────────────────────────
+
+interface ColorInputProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function ColorInput({ value, onChange }: ColorInputProps) {
+  const isValid = /^#[0-9A-Fa-f]{6}$/.test(value);
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="color"
+        value={isValid ? value : '#7c3aed'}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-10 h-9 rounded cursor-pointer border border-[#2a2a40] bg-[#13131a] p-0.5"
+        title="Pick a color"
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={7}
+        placeholder="#7c3aed"
+        className={`input flex-1 font-mono text-sm ${!isValid && value ? 'border-red-600/60' : ''}`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/stations/page.tsx
+++ b/frontend/src/app/stations/page.tsx
@@ -222,6 +222,12 @@ export default function StationsPage() {
                         Edit
                       </button>
                       <button
+                        onClick={() => router.push(`/stations/${station.id}/details`)}
+                        className="text-xs text-teal-400 hover:text-teal-300 font-medium"
+                      >
+                        Details
+                      </button>
+                      <button
                         onClick={() => router.push(`/stations/${station.id}/settings`)}
                         className="text-xs text-blue-400 hover:text-blue-300 font-medium"
                       >

--- a/services/station/src/routes/stations.ts
+++ b/services/station/src/routes/stations.ts
@@ -46,6 +46,49 @@ export async function stationRoutes(app: FastifyInstance) {
 
   app.put('/stations/:id', {
     onRequest: [requirePermission('station:write'), requireStationAccess()],
+    schema: {
+      body: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          // Core fields
+          name: { type: 'string', minLength: 1, maxLength: 255 },
+          timezone: { type: 'string', maxLength: 100 },
+          broadcast_start_hour: { type: 'integer', minimum: 0, maximum: 23 },
+          broadcast_end_hour: { type: 'integer', minimum: 0, maximum: 23 },
+          active_days: { type: 'array', items: { type: 'string' } },
+          is_active: { type: 'boolean' },
+          dj_enabled: { type: 'boolean' },
+          dj_auto_approve: { type: 'boolean' },
+          openai_api_key: { type: 'string' },
+          elevenlabs_api_key: { type: 'string' },
+          openrouter_api_key: { type: 'string' },
+          // Identity (migration 039)
+          callsign: { type: ['string', 'null'], maxLength: 10 },
+          tagline: { type: ['string', 'null'], maxLength: 255 },
+          frequency: { type: ['string', 'null'], maxLength: 20 },
+          broadcast_type: { type: ['string', 'null'], enum: ['fm', 'am', 'online', 'podcast', 'dab', null] },
+          // Locale
+          city: { type: ['string', 'null'], maxLength: 100 },
+          province: { type: ['string', 'null'], maxLength: 100 },
+          country: { type: ['string', 'null'], maxLength: 100 },
+          locale_code: { type: ['string', 'null'], maxLength: 20 },
+          latitude: { type: ['number', 'null'], minimum: -90, maximum: 90 },
+          longitude: { type: ['number', 'null'], minimum: -180, maximum: 180 },
+          // Social media
+          facebook_page_id: { type: ['string', 'null'], maxLength: 100 },
+          facebook_page_url: { type: ['string', 'null'], maxLength: 255 },
+          twitter_handle: { type: ['string', 'null'], maxLength: 100 },
+          instagram_handle: { type: ['string', 'null'], maxLength: 100 },
+          youtube_channel_url: { type: ['string', 'null'], maxLength: 255 },
+          // Branding
+          logo_url: { type: ['string', 'null'], maxLength: 500 },
+          primary_color: { type: ['string', 'null'], pattern: '^#[0-9A-Fa-f]{6}$' },
+          secondary_color: { type: ['string', 'null'], pattern: '^#[0-9A-Fa-f]{6}$' },
+          website_url: { type: ['string', 'null'], maxLength: 255 },
+        },
+      },
+    },
   }, async (req, reply) => {
     const { id } = req.params as { id: string };
     const station = await stationService.updateStation(id, req.body as Parameters<typeof stationService.updateStation>[1]);

--- a/services/station/src/services/stationService.ts
+++ b/services/station/src/services/stationService.ts
@@ -63,11 +63,46 @@ export async function updateStation(id: string, data: Partial<{
   openai_api_key: string;
   elevenlabs_api_key: string;
   openrouter_api_key: string;
+  // Identity (migration 039)
+  callsign: string;
+  tagline: string;
+  frequency: string;
+  broadcast_type: string;
+  // Locale
+  city: string;
+  province: string;
+  country: string;
+  locale_code: string;
+  latitude: number;
+  longitude: number;
+  // Social media
+  facebook_page_id: string;
+  facebook_page_url: string;
+  twitter_handle: string;
+  instagram_handle: string;
+  youtube_channel_url: string;
+  // Branding
+  logo_url: string;
+  primary_color: string;
+  secondary_color: string;
+  website_url: string;
 }>): Promise<Station | null> {
   const fields: string[] = [];
   const values: unknown[] = [];
   let i = 1;
-  const allowed = ['name','timezone','broadcast_start_hour','broadcast_end_hour','active_days','is_active','dj_enabled','dj_auto_approve', 'openai_api_key', 'elevenlabs_api_key', 'openrouter_api_key'] as const;
+  const allowed = [
+    'name', 'timezone', 'broadcast_start_hour', 'broadcast_end_hour', 'active_days',
+    'is_active', 'dj_enabled', 'dj_auto_approve',
+    'openai_api_key', 'elevenlabs_api_key', 'openrouter_api_key',
+    // Identity
+    'callsign', 'tagline', 'frequency', 'broadcast_type',
+    // Locale
+    'city', 'province', 'country', 'locale_code', 'latitude', 'longitude',
+    // Social media
+    'facebook_page_id', 'facebook_page_url', 'twitter_handle', 'instagram_handle', 'youtube_channel_url',
+    // Branding
+    'logo_url', 'primary_color', 'secondary_color', 'website_url',
+  ] as const;
   for (const key of allowed) {
     if (data[key] !== undefined) { fields.push(`${key} = $${i++}`); values.push(data[key]); }
   }

--- a/shared/db/src/migrations/039_add_station_details.sql
+++ b/shared/db/src/migrations/039_add_station_details.sql
@@ -1,0 +1,32 @@
+-- Migration 039: Add station details columns
+-- Identity, locale, social media, and branding fields for the Station Details page.
+-- All columns are nullable to preserve backward compatibility.
+
+ALTER TABLE stations
+  -- Identity
+  ADD COLUMN IF NOT EXISTS callsign VARCHAR(10),
+  ADD COLUMN IF NOT EXISTS tagline VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS frequency VARCHAR(20),
+  ADD COLUMN IF NOT EXISTS broadcast_type VARCHAR(20) DEFAULT 'fm'
+    CHECK (broadcast_type IN ('fm', 'am', 'online', 'podcast', 'dab')),
+
+  -- Locale
+  ADD COLUMN IF NOT EXISTS city VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS province VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS country VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS locale_code VARCHAR(20),
+  ADD COLUMN IF NOT EXISTS latitude DECIMAL(9,6),
+  ADD COLUMN IF NOT EXISTS longitude DECIMAL(9,6),
+
+  -- Social media
+  ADD COLUMN IF NOT EXISTS facebook_page_id VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS facebook_page_url VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS twitter_handle VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS instagram_handle VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS youtube_channel_url VARCHAR(255),
+
+  -- Branding
+  ADD COLUMN IF NOT EXISTS logo_url VARCHAR(500),
+  ADD COLUMN IF NOT EXISTS primary_color VARCHAR(7),
+  ADD COLUMN IF NOT EXISTS secondary_color VARCHAR(7),
+  ADD COLUMN IF NOT EXISTS website_url VARCHAR(255);

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -199,6 +199,29 @@ export interface Station {
   sort_order?: number;
   created_at: Date;
   updated_at: Date;
+  // Identity (added in migration 039)
+  callsign?: string | null;
+  tagline?: string | null;
+  frequency?: string | null;
+  broadcast_type?: 'fm' | 'am' | 'online' | 'podcast' | 'dab' | null;
+  // Locale
+  city?: string | null;
+  province?: string | null;
+  country?: string | null;
+  locale_code?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  // Social media
+  facebook_page_id?: string | null;
+  facebook_page_url?: string | null;
+  twitter_handle?: string | null;
+  instagram_handle?: string | null;
+  youtube_channel_url?: string | null;
+  // Branding
+  logo_url?: string | null;
+  primary_color?: string | null;
+  secondary_color?: string | null;
+  website_url?: string | null;
 }
 
 export interface Role {

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -13,10 +13,10 @@ Before starting any task, an agent MUST:
 9. **ACCEPTANCE CRITERIA MANDATE**: NEVER move a ticket to Done unless ALL `- [ ]` acceptance criteria in the GitHub issue are checked off (`- [x]`). Verify with `gh issue view <N>` before calling `gh project item-edit` to set status Done. Check off each criterion as it is implemented in the merged PR.
 
 ## Active Work
-- [ ] Fix DJ Script generation INTERNAL_ERROR — missing API key validation + unmasked LLM errors (issue #183, fix/issue-183) | @claude-code | 2026-04-05
-- [ ] Tiered user permission system — subscriptions, custom roles, station hierarchy, thin JWT (issue #216, feat/issue-216-tiered-permissions) | @claude-code | 2026-04-06
+- [ ] Station Details page — locale, callsign, social handles, system metadata (issue #202, feat/issue-202-station-details) | @claude-code | 2026-04-06
 
 ## Recently Completed
+- [x] Tiered user permission system — subscriptions, custom roles, station hierarchy, thin JWT (issue #216, PR #218, feat/issue-216-tiered-permissions-v2) | @claude-code | 2026-04-06
 - [x] Google OAuth login (issue #200, feat/issue-200-google-oauth) | @claude-code | 2026-04-05
 - [x] Fix DJ INTERNAL_ERROR: reject handler 422/503 error codes (issue #183, fix/issue-183-dj-error) | @claude-code | 2026-04-05
 - [x] Agent workflow improvements — P0 daemon fixes + CLAUDE.md rules (issue #158, feat/issue-158-workflow-improvements) | @claude-code | 2026-04-05


### PR DESCRIPTION
## Summary

Implements issue #202 — a comprehensive Station Details page that provides a single source of truth for station identity and locale data. This is the prerequisite for Weather, Current Events, Time Check, Station ID, and Listener Activity DJ segments.

## Changes

### DB Migration (039)
Adds 19 nullable columns to `stations` (fully backward-compatible, all `IF NOT EXISTS`):
- **Identity**: `callsign`, `tagline`, `frequency`, `broadcast_type` (fm/am/online/podcast/dab)
- **Locale**: `city`, `province`, `country`, `locale_code`, `latitude`, `longitude`
- **Social**: `facebook_page_id`, `facebook_page_url`, `twitter_handle`, `instagram_handle`, `youtube_channel_url`
- **Branding**: `logo_url`, `primary_color`, `secondary_color`, `website_url`

### Backend
- `PUT /stations/:id` extended with full schema validation (hex color pattern `^#[0-9A-Fa-f]{6}$`, lat/lng bounds, broadcast_type enum)
- `stationService.updateStation()` accepts all new fields

### Frontend
- New: `/stations/:id/details` — 4-section form with live preview card
- Updated: `/stations` list — "Details" button per station row

## Test Plan
- [x] typecheck: all 12 workspace packages pass
- [x] lint: 0 errors
- [x] 182 unit tests pass

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)