### PR TITLE
feat(dj): Weather segment — IDataProvider interface, MockWeatherAdapter, and weather_tease template seed (#207)

### DIFF
--- a/services/dj/src/adapters/data/index.ts
+++ b/services/dj/src/adapters/data/index.ts
@@ -2,3 +2,4 @@ export type { IDataProvider, WeatherData, NewsItem, WeatherProviderConfig, NewsP
 export { openWeatherMapProvider } from './openWeatherMap.js';
 export { newsApiProvider } from './newsApi.js';
 export { ddgWeatherSearch, ddgNewsSearch, cityFromTimezone } from './duckDuckGo.js';
+export { mockWeatherProvider, mockIWeatherProvider, mockWeatherData } from './mock.js';

--- a/services/dj/src/adapters/data/mock.ts
+++ b/services/dj/src/adapters/data/mock.ts
@@ -1,0 +1,49 @@
+/**
+ * MockWeatherAdapter — returns deterministic fake weather data.
+ * Use in unit tests instead of hitting the real OpenWeatherMap API.
+ */
+import type { IDataProvider, WeatherData, WeatherProviderConfig } from './interface.js';
+import type { IWeatherProvider } from '@playgen/types';
+import type { WeatherForecast } from '@playgen/types';
+
+/** Fake WeatherData (matches the WeatherData shape from interface.ts). */
+export const mockWeatherData: WeatherData = {
+  city: 'TestCity',
+  condition: 'Sunny',
+  temperature_c: 25,
+  humidity_pct: 60,
+  wind_kph: 15,
+  summary: 'Sunny, 25°C, 15 kph winds',
+};
+
+/** IDataProvider<WeatherProviderConfig, WeatherData> implementation for tests. */
+export const mockWeatherProvider: IDataProvider<WeatherProviderConfig, WeatherData> = {
+  isConfigured(_cfg: WeatherProviderConfig): boolean {
+    return true;
+  },
+  async fetch(_cfg: WeatherProviderConfig): Promise<WeatherData> {
+    return { ...mockWeatherData };
+  },
+};
+
+/** IWeatherProvider implementation for tests. */
+export const mockIWeatherProvider: IWeatherProvider = {
+  async fetchForecast(
+    _lat: number | null,
+    _lon: number | null,
+    city: string,
+  ): Promise<WeatherForecast> {
+    const tempC = 25;
+    const tempF = Math.round(tempC * 9 / 5 + 32);
+    return {
+      city: city || 'TestCity',
+      temperature_c: tempC,
+      temperature_f: tempF,
+      conditions: 'Sunny',
+      description: 'clear skies and sunshine',
+      humidity: 60,
+      wind_speed_kmh: 15,
+      summary: `Sunny, ${tempC}°C (${tempF}°F), 15 kph winds`,
+    };
+  },
+};

--- a/services/dj/tests/unit/weatherAdapter.test.ts
+++ b/services/dj/tests/unit/weatherAdapter.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { openWeatherMapProvider } from '../../src/adapters/data/openWeatherMap.js';
+import { mockWeatherProvider, mockIWeatherProvider, mockWeatherData } from '../../src/adapters/data/mock.js';
+import type { WeatherProviderConfig } from '../../src/adapters/data/interface.js';
+
+// ─── OpenWeatherMapAdapter ────────────────────────────────────────────────────
+
+describe('openWeatherMapProvider', () => {
+  describe('isConfigured', () => {
+    it('returns true when api_key and city are provided', () => {
+      const cfg: WeatherProviderConfig = { api_key: 'test-key', city: 'Manila' };
+      expect(openWeatherMapProvider.isConfigured(cfg)).toBe(true);
+    });
+
+    it('returns true when api_key and lat/lon are provided', () => {
+      const cfg: WeatherProviderConfig = { api_key: 'test-key', city: '', lat: 14.5, lon: 121.0 };
+      expect(openWeatherMapProvider.isConfigured(cfg)).toBe(true);
+    });
+
+    it('returns false when api_key is missing', () => {
+      const cfg: WeatherProviderConfig = { api_key: '', city: 'Manila' };
+      expect(openWeatherMapProvider.isConfigured(cfg)).toBe(false);
+    });
+
+    it('returns false when both city and coords are missing', () => {
+      const cfg: WeatherProviderConfig = { api_key: 'test-key', city: '' };
+      expect(openWeatherMapProvider.isConfigured(cfg)).toBe(false);
+    });
+  });
+
+  describe('fetch', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it('fetches weather data by city and returns WeatherData shape', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: 'Manila',
+          weather: [{ description: 'light rain' }],
+          main: { temp: 30, humidity: 80 },
+          wind: { speed: 5 },
+        }),
+      } as Response);
+
+      const cfg: WeatherProviderConfig = { api_key: 'test-key', city: 'Manila' };
+      const result = await openWeatherMapProvider.fetch(cfg);
+
+      expect(result.city).toBe('Manila');
+      expect(result.temperature_c).toBe(30);
+      expect(result.condition).toBe('light rain');
+      expect(result.humidity_pct).toBe(80);
+      expect(result.wind_kph).toBe(18); // 5 m/s × 3.6
+      expect(result.summary).toMatch(/Light rain/);
+    });
+
+    it('fetches weather data by lat/lon coordinates', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: 'Quezon City',
+          weather: [{ description: 'clear sky' }],
+          main: { temp: 28, humidity: 70 },
+          wind: { speed: 3 },
+        }),
+      } as Response);
+
+      const cfg: WeatherProviderConfig = { api_key: 'test-key', city: 'QC', lat: 14.6760, lon: 121.0437 };
+      const result = await openWeatherMapProvider.fetch(cfg);
+
+      // Verify lat/lon params were used (the URL should have lat= and lon= not q=)
+      const calledUrl = String(fetchSpy.mock.calls[0]?.[0] ?? '');
+      expect(calledUrl).toContain('lat=');
+      expect(calledUrl).toContain('lon=');
+      expect(calledUrl).not.toContain('q=');
+      expect(result.city).toBe('Quezon City');
+    });
+
+    it('throws an error when the API returns a non-2xx status', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => 'Invalid API key',
+      } as Response);
+
+      const cfg: WeatherProviderConfig = { api_key: 'bad-key', city: 'Manila' };
+      await expect(openWeatherMapProvider.fetch(cfg)).rejects.toThrow('OpenWeatherMap error 401');
+    });
+  });
+});
+
+// ─── MockWeatherAdapter ───────────────────────────────────────────────────────
+
+describe('mockWeatherProvider', () => {
+  it('is always configured', () => {
+    expect(mockWeatherProvider.isConfigured({ api_key: '', city: '' })).toBe(true);
+    expect(mockWeatherProvider.isConfigured({ api_key: 'any', city: 'any' })).toBe(true);
+  });
+
+  it('returns deterministic fake WeatherData', async () => {
+    const result = await mockWeatherProvider.fetch({ api_key: '', city: 'Anywhere' });
+    expect(result).toMatchObject({
+      city: mockWeatherData.city,
+      temperature_c: mockWeatherData.temperature_c,
+      condition: mockWeatherData.condition,
+    });
+  });
+
+  it('returns a new object on each call (no shared reference)', async () => {
+    const r1 = await mockWeatherProvider.fetch({ api_key: '', city: '' });
+    const r2 = await mockWeatherProvider.fetch({ api_key: '', city: '' });
+    expect(r1).not.toBe(r2);
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ─── MockIWeatherProvider ─────────────────────────────────────────────────────
+
+describe('mockIWeatherProvider', () => {
+  it('returns a WeatherForecast with temperature in both C and F', async () => {
+    const forecast = await mockIWeatherProvider.fetchForecast(null, null, 'TestCity');
+    expect(forecast.temperature_c).toBe(25);
+    expect(forecast.temperature_f).toBe(77); // (25 * 9/5) + 32
+    expect(forecast.conditions).toBe('Sunny');
+    expect(forecast.description).toBeTruthy();
+    expect(forecast.summary).toContain('25°C');
+    expect(forecast.summary).toContain('77°F');
+  });
+
+  it('uses the provided city name', async () => {
+    const forecast = await mockIWeatherProvider.fetchForecast(14.5, 121.0, 'Manila');
+    expect(forecast.city).toBe('Manila');
+  });
+
+  it('falls back to TestCity when no city is provided', async () => {
+    const forecast = await mockIWeatherProvider.fetchForecast(null, null, '');
+    expect(forecast.city).toBe('TestCity');
+  });
+
+  it('includes all required WeatherForecast fields', async () => {
+    const forecast = await mockIWeatherProvider.fetchForecast(null, null, 'Any');
+    expect(forecast).toHaveProperty('city');
+    expect(forecast).toHaveProperty('temperature_c');
+    expect(forecast).toHaveProperty('temperature_f');
+    expect(forecast).toHaveProperty('conditions');
+    expect(forecast).toHaveProperty('description');
+    expect(forecast).toHaveProperty('humidity');
+    expect(forecast).toHaveProperty('wind_speed_kmh');
+    expect(forecast).toHaveProperty('summary');
+  });
+});

--- a/shared/db/src/migrations/046_add_new_segment_type_defaults_to_dj_templates.sql
+++ b/shared/db/src/migrations/046_add_new_segment_type_defaults_to_dj_templates.sql
@@ -32,6 +32,11 @@ CROSS JOIN (
         'listener_activity'::dj_segment_type,
         'Default Listener Activity',
         'Invite listeners to connect — shout out the station''s social media, invite song requests, or tease an upcoming listener contest. Keep it energetic and under 3 sentences.'
+    ),
+    (
+        'weather_tease'::dj_segment_type,
+        'Default Weather Tease',
+        '{{#weather}}Give a quick, conversational weather update for {{station_city}}: {{weather_summary}}. Work it naturally into the show — tie it to what listeners might be doing or feeling. Keep it to 1-2 sentences.{{/weather}}{{^weather}}Tease that weather info is coming up, or mention the weather vibe outside right now in one punchy sentence.{{/weather}}'
     )
 ) AS t(segment_type, name, prompt_template)
 WHERE NOT EXISTS (

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -537,6 +537,35 @@ export interface DjScriptWithSegments extends DjScript {
   segments: DjSegment[];
 }
 
+// ─── Weather / Data Plugins ───────────────────────────────────────────────────
+
+/** Live weather forecast returned by any weather provider. */
+export interface WeatherForecast {
+  city: string;
+  temperature_c: number;
+  temperature_f: number;
+  conditions: string;       // Short label, e.g. "Partly Cloudy"
+  description: string;      // Longer description, e.g. "partly cloudy skies"
+  humidity: number;         // 0–100 %
+  wind_speed_kmh: number;
+  summary: string;          // Human-readable one-liner for prompt injection
+}
+
+/** Generic extensible data-provider interface.
+ *  Implement this to add new weather/news/data backends. */
+export interface IDataProvider<TConfig = unknown, TResult = unknown> {
+  /** Returns true when required config keys are present and non-empty. */
+  isConfigured(cfg: TConfig): boolean;
+  /** Fetches live data. Throws on unrecoverable error. */
+  fetch(cfg: TConfig): Promise<TResult>;
+}
+
+/** Dedicated weather-provider interface (higher-level than IDataProvider). */
+export interface IWeatherProvider {
+  /** Fetch a forecast for the given coordinates and/or city name. */
+  fetchForecast(lat: number | null, lon: number | null, city: string): Promise<WeatherForecast>;
+}
+
 // ─── Station Settings ─────────────────────────────────────────────────────────
 
 /** Known per-station setting keys managed via the settings UI. */
@@ -545,7 +574,9 @@ export type StationSettingKey =
   | 'tts_api_key'
   | 'tts_voice_id'
   | 'llm_model'
-  | 'llm_api_key';
+  | 'llm_api_key'
+  | 'weather_provider'
+  | 'weather_api_key';
 
 export interface StationSetting {
   id: string;

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -14,6 +14,7 @@ Before starting any task, an agent MUST:
 
 ## Active Work
 - [ ] feat(dj): Jokes segment (issue #205, feat/issue-205-dj-jokes) | @claude-code | 2026-04-06 | Migration: 044
+- [ ] feat(dj): Weather segment (issue #207, feat/issue-207-dj-weather) | @claude-code | 2026-04-06
 - [ ] Fix DJ Script generation INTERNAL_ERROR — missing API key validation + unmasked LLM errors (issue #183, fix/issue-183) | @claude-code | 2026-04-05
 - [ ] arch: Program as higher-tier entity — programs + program_episodes (issue #210, feat/issue-210-program-entity) | @claude-code | 2026-04-06 | Migration: 034-035
 - [ ] feat(auth): real email reset + verification (issue #224, feat/issue-224-email-reset-verification) | @claude-code | 2026-04-06 | Migration: 047-048


### PR DESCRIPTION
## Summary

- Defines `WeatherForecast`, `IDataProvider<TConfig, TResult>`, and `IWeatherProvider` interfaces in `@playgen/types` (resolving the AC requirement for shared-types placement)
- Adds `weather_provider` and `weather_api_key` to the `StationSettingKey` union type so the settings UI can surface these keys
- Creates `MockWeatherAdapter` (`mockWeatherProvider` + `mockIWeatherProvider`) in `services/dj/src/adapters/data/mock.ts` for use in unit tests
- Adds 14 unit tests in `weatherAdapter.test.ts` covering `isConfigured`, city fetch, lat/lon fetch, API error handling, and all mock methods
- Seeds a default `weather_tease` prompt template for all stations in migration 046 using the `{{#weather}}...{{/weather}}` conditional block already supported by the prompt builder

The weather data fetch pipeline (OpenWeatherMap primary + DuckDuckGo fallback), prompt builder interpolation (`{{weather_summary}}`, `{{weather_temp}}`, `{{weather_condition}}`), graceful error handling, and the `weather_api_key` column (migration 045) were already merged into main as part of the broader data-provider refactor.

## Acceptance Criteria

- [x] `IDataProvider` interface defined in shared types (`@playgen/types`)
- [x] `OpenWeatherMapAdapter` implemented and tested (14 unit tests in `weatherAdapter.test.ts`)
- [x] Station config extended with `weather_provider` and `weather_api_key` fields (migration 045 + `StationSettingKey`)
- [x] Station locale (city, coordinates from migration 039/045) used for API query
- [x] Live forecast data injected into prompt context (`weatherData` → `ScriptContext.weather` in `generationWorker.ts`)
- [x] Default weather prompt template exists and is seeded (migration 046 + `SEGMENT_DEFAULTS.weather_tease`)
- [x] User can edit generated script text before TTS (existing script review UI)
- [x] TTS generates and stores audio (existing per-segment TTS endpoint)
- [x] Falls back gracefully if weather API is unconfigured or fails (DuckDuckGo fallback + try/catch in `generationWorker.ts`)
- [x] MockWeatherAdapter available for unit tests (`mockWeatherProvider`, `mockIWeatherProvider`)

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run test:unit` — 107 tests pass (14 new weather adapter tests)

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)