### PR TITLE
fix(cd): add retry logic to smoke tests for slow Railway deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -151,10 +151,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Wait for deployments to stabilize
-        run: sleep 180
+        run: sleep 60
 
       - name: Run smoke tests
         run: bash scripts/smoke-test.sh
         env:
           GATEWAY_URL: ${{ vars.PRODUCTION_GATEWAY_URL }}
           FRONTEND_URL: ${{ vars.PRODUCTION_FRONTEND_URL }}
+          MAX_RETRIES: "12"
+          RETRY_INTERVAL: "15"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 GATEWAY_URL="${GATEWAY_URL:?GATEWAY_URL must be set}"
 FRONTEND_URL="${FRONTEND_URL:-}"
+MAX_RETRIES="${MAX_RETRIES:-10}"
+RETRY_INTERVAL="${RETRY_INTERVAL:-15}"
 
 FAILED=0
 
@@ -11,27 +13,45 @@ check() {
   local url="$2"
   local status
   status=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null || echo "000")
-  if [ "$status" = "200" ]; then
-    echo "[PASS] $name -> $status"
-  else
-    echo "[FAIL] $name -> $status"
-    FAILED=1
-  fi
+  echo "$status"
+}
+
+check_with_retry() {
+  local name="$1"
+  local url="$2"
+  local attempt=1
+  local status
+
+  while [ $attempt -le "$MAX_RETRIES" ]; do
+    status=$(check "$name" "$url")
+    if [ "$status" = "200" ]; then
+      echo "[PASS] $name -> $status"
+      return 0
+    fi
+    if [ $attempt -lt "$MAX_RETRIES" ]; then
+      echo "[RETRY] $name -> $status (attempt $attempt/$MAX_RETRIES, waiting ${RETRY_INTERVAL}s)"
+      sleep "$RETRY_INTERVAL"
+    else
+      echo "[FAIL] $name -> $status (exhausted $MAX_RETRIES attempts)"
+    fi
+    attempt=$((attempt + 1))
+  done
+  FAILED=1
 }
 
 echo "=== Gateway Health ==="
-check "gateway" "${GATEWAY_URL}/health"
+check_with_retry "gateway" "${GATEWAY_URL}/health"
 
 echo ""
 echo "=== Per-Service Health (via gateway proxy) ==="
 for svc in auth station library scheduler playlist analytics dj; do
-  check "$svc" "${GATEWAY_URL}/health/${svc}"
+  check_with_retry "$svc" "${GATEWAY_URL}/health/${svc}"
 done
 
 if [ -n "$FRONTEND_URL" ]; then
   echo ""
   echo "=== Frontend Health ==="
-  check "frontend" "$FRONTEND_URL"
+  check_with_retry "frontend" "$FRONTEND_URL"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Add retry logic to `scripts/smoke-test.sh` — each service gets up to 12 attempts with 15s intervals before failing
- Reduce static sleep in CD workflow from 180s to 60s since retries handle the waiting adaptively
- Fixes consistently failing smoke tests for `auth` and `station` services that aren't ready when checked

Closes #233

## Test plan
- [ ] Verify CI (typecheck, lint, unit tests) passes
- [ ] Confirm next CD run on main completes smoke tests successfully
- [ ] Verify no increase in total pipeline duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)