### PR TITLE
fix(db): use plain btree index instead of date_trunc expression index

### DIFF
--- a/shared/db/src/migrations/051_create_dj_usage_log.sql
+++ b/shared/db/src/migrations/051_create_dj_usage_log.sql
@@ -30,7 +30,8 @@ CREATE TABLE dj_usage_log (
 );
 
 -- Index for the monthly usage query (GET /stations/:id/dj/usage?month=YYYY-MM)
-CREATE INDEX idx_dj_usage_log_station_month
-  ON dj_usage_log(station_id, date_trunc('month', created_at));
+-- date_trunc on TIMESTAMPTZ is STABLE not IMMUTABLE, so use a plain btree.
+CREATE INDEX idx_dj_usage_log_station_created
+  ON dj_usage_log(station_id, created_at);
 
 COMMENT ON COLUMN dj_usage_log.metadata IS 'Arbitrary key-value context stored as JSONB — e.g. segment_type for LLM rows, voice_id for TTS rows.';


### PR DESCRIPTION
## Summary
- Fix migration 051 that fails with `functions in index expression must be marked IMMUTABLE`
- `date_trunc('month', created_at)` on a `TIMESTAMPTZ` column is `STABLE`, not `IMMUTABLE` — PostgreSQL rejects it for expression indexes
- Replace with a plain btree on `(station_id, created_at)` which supports the same range queries

## Test plan
- [ ] CD pipeline passes (migration runs successfully on Railway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)