### PR TITLE
fix(programs): UX polish M1-M6 — empty state, day presets, card labels, time display, clock validation, confirm modal (closes #253)

### DIFF
--- a/frontend/src/app/programs/[id]/clock/page.tsx
+++ b/frontend/src/app/programs/[id]/clock/page.tsx
@@ -208,6 +208,18 @@ export default function ShowClockEditorPage() {
 
   async function saveClock() {
     if (!current) return;
+
+    // M5: validate target_minute is in 0–59 range before saving
+    const badMinuteIdx = current.slots.findIndex(s => {
+      if (s.target_minute === '') return false;
+      const m = Number(s.target_minute);
+      return isNaN(m) || !Number.isInteger(m) || m < 0 || m > 59;
+    });
+    if (badMinuteIdx !== -1) {
+      setError(`Slot ${badMinuteIdx + 1}: target minute must be a whole number between 0 and 59.`);
+      return;
+    }
+
     setSaving(true);
     setError('');
     try {

--- a/frontend/src/app/programs/[id]/page.tsx
+++ b/frontend/src/app/programs/[id]/page.tsx
@@ -111,6 +111,8 @@ export default function ProgramDetailPage() {
   const [editDesc, setEditDesc] = useState('');
   const [editActive, setEditActive] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     const user = getCurrentUser();
@@ -175,9 +177,14 @@ export default function ProgramDetailPage() {
 
   async function deleteProgram() {
     if (!program || program.is_default) return;
-    if (!window.confirm(`Delete "${program.name}"? All episodes will be moved to Unassigned.`)) return;
-    await api.delete<unknown>(`/api/v1/programs/${program.id}`);
-    router.push('/programs');
+    setDeleting(true);
+    try {
+      await api.delete<unknown>(`/api/v1/programs/${program.id}`);
+      router.push('/programs');
+    } finally {
+      setDeleting(false);
+      setShowDeleteConfirm(false);
+    }
   }
 
   if (loading) {
@@ -474,7 +481,7 @@ export default function ProgramDetailPage() {
           <div className="border-t border-[#2a2a40] pt-5 mt-5">
             <h3 className="text-red-400 text-sm font-medium mb-2">Danger Zone</h3>
             <button
-              onClick={deleteProgram}
+              onClick={() => setShowDeleteConfirm(true)}
               className="text-sm text-red-500 hover:text-red-400 border border-red-900/40 px-4 py-2 rounded-lg transition-colors"
             >
               Delete Program
@@ -485,6 +492,35 @@ export default function ProgramDetailPage() {
       )}
       {tab === 'settings' && program.is_default && (
         <p className="text-gray-500 text-sm">The default program cannot be edited or deleted.</p>
+      )}
+
+      {/* Delete confirmation modal */}
+      {showDeleteConfirm && program && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/60" onClick={() => setShowDeleteConfirm(false)} />
+          <div className="relative bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-6 w-full max-w-md shadow-xl">
+            <h3 className="text-white font-semibold mb-2">Delete &ldquo;{program.name}&rdquo;?</h3>
+            <p className="text-gray-400 text-sm mb-6">
+              All episodes will be moved to the <span className="text-gray-300">Unassigned</span> default program. This action cannot be undone.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={deleting}
+                className="px-4 py-2 text-sm text-gray-300 hover:text-white bg-[#12122a] hover:bg-[#1e1e3a] border border-[#2a2a40] rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={deleteProgram}
+                disabled={deleting}
+                className="px-4 py-2 text-sm text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 rounded-lg transition-colors"
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Six targeted UX fixes for the Programs module user journey (§6 M1-M6):

| # | Item | Change |
|---|---|---|
| M1 | Empty state copy | Rewrote description to explain the Show Clock concept and reference example show names |
| M2 | Day presets | Added **Weekdays / Weekend / Daily** quick-select buttons above the day toggles in the New Program form |
| M3 | Card action labels | Gear icon (was a broken no-op) now links to the program detail page; "View Episodes" shortened to "Episodes" for visual balance |
| M4 | 12 AM vs 24H display | List-page `formatHour` unified to short form (`12 AM` / `12 PM`) matching the detail page — eliminates `12:00 AM` vs `12 AM` inconsistency |
| M5 | Clock minute validation | `saveClock()` validates `target_minute` is an integer 0–59 before the API call; shows a per-slot error message if out of range |
| M6 | In-app confirm modal | Replaced `window.confirm()` with a custom overlay modal (Cancel + Delete buttons + consequence message) |

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — passes
- [x] `pnpm run test:unit` — all test suites pass
- [x] Empty state renders correctly when no programs exist
- [x] Day preset buttons set the correct `activeDays` state
- [x] Gear icon now navigates to the program detail page
- [x] `formatHour` returns consistent short format in both list and detail views
- [x] Attempting to save a clock slot with `target_minute` outside 0–59 shows inline error and does not call the API
- [x] Delete Program shows a modal; Cancel dismisses it; Delete calls the API and redirects to /programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)