### PR TITLE
feat(frontend): Stations sidebar + zero-station onboarding CTA

### DIFF
--- a/frontend/src/app/programs/new/page.tsx
+++ b/frontend/src/app/programs/new/page.tsx
@@ -116,6 +116,25 @@ export default function NewProgramPage() {
         </div>
       </div>
 
+      {stations.length === 0 ? (
+        <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-8 text-center">
+          <div className="w-14 h-14 bg-violet-600/10 rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <svg className="w-7 h-7 text-violet-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
+            </svg>
+          </div>
+          <h3 className="text-white font-semibold mb-2">You need a station first</h3>
+          <p className="text-gray-500 text-sm mb-5 max-w-sm mx-auto">
+            Programs belong to a station. Create one to unlock the rest of the setup.
+          </p>
+          <Link
+            href="/stations"
+            className="inline-block bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium px-5 py-2.5 rounded-lg transition-colors"
+          >
+            Create a station →
+          </Link>
+        </div>
+      ) : (
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Station */}
         {stations.length > 1 && (
@@ -261,6 +280,7 @@ export default function NewProgramPage() {
           </button>
         </div>
       </form>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ClientLayout.tsx
+++ b/frontend/src/components/ClientLayout.tsx
@@ -17,6 +17,14 @@ const NAV_LINKS = [
     ),
   },
   {
+    href: '/stations', label: 'Stations',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728m-9.9-2.829a5 5 0 010-7.07m7.072 0a5 5 0 010 7.07M13 12a1 1 0 11-2 0 1 1 0 012 0z"/>
+      </svg>
+    ),
+  },
+  {
     href: '/library', label: 'Library',
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Sidebar now has a Stations link (#248) — Station CRUD was previously undiscoverable
- /programs/new with 0 stations shows a 'Create a station first' CTA instead of silently 422ing (#249)

## Test plan
- [x] pnpm run typecheck (frontend builds)
- [x] Manual walkthrough in local Docker stack

Stacked on top of #280. Base: feat/programs-user-journey-e2e. Will rebase onto main after #280 merges.

Closes #248 #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)