### PR TITLE
feat(ux): unify Programs + Logs around 'The Log' — /today + band overlay

### DIFF
--- a/docs/user-journey-programs-logs.md
+++ b/docs/user-journey-programs-logs.md
@@ -1,0 +1,134 @@
+# User Journey — Programs & Logs (unified)
+
+> Supersedes `docs/user-journey-programs.md` (kept as historical reference for the Programs-only walkthrough).
+
+## Why this doc exists
+
+PlayGen shipped Programs and Playlists as two parallel concepts:
+
+- **Programs** define *what* airs (recurring show, days, hours, Show Clock, DJ profile).
+- **Playlists** define *what actually ran* on a given date (24-hour station log).
+
+The two never meet in the UI:
+
+1. Clocks exist under Programs but **do not drive generation** — logs are built from Templates.
+2. There is no "now playing" view — board-ops can't see today's airtime at a glance.
+3. You can't jump from a Playlist back to the Program that owns an hour, or from a Program back to the generated log for today.
+4. Coverage gaps (hours with no Program) are invisible until a director notices silence on-air.
+
+This doc defines the unified model, the new information architecture, and the three primary user journeys. It is the source of truth that every future ticket under this initiative must reference in its acceptance criteria.
+
+---
+
+## Mental model
+
+Adopted from industry convention (RCS GSelector, Music Master, PowerGold):
+
+```
+Station Log (daily, per station)
+  └── Program Bands (hourly blocks owned by a Program)
+        └── Show Clock (60-min format wheel)
+              └── Clock Slots → Library categories
+```
+
+- A **Log** is the concrete output for `(station, date)`. One per station per day. (DB: `playlists` table.)
+- A **Program** is a recurring show definition. It owns hours and a default Clock. (DB: `programs`.)
+- An **Episode** is a Program's slice of a specific Log (per-day metadata: DJ script, approval, notes). (DB: `program_episodes`.)
+- A **Clock** is the hour-shaped rotation template. (DB: `show_format_clocks` + `show_clock_slots`.)
+- **Templates** are demoted to "Default Clock Library" — the fallback used when no Program covers an hour.
+
+No destructive schema migration is needed to ship the unified UI. The schema already supports this model; the UI just needs to surface it.
+
+---
+
+## Information architecture
+
+Sidebar order (see `frontend/src/components/ClientLayout.tsx`):
+
+1. **Today** — new landing for all personas
+2. **Dashboard** — retained for company-wide KPIs
+3. **Stations**
+4. **Library**
+5. **Programs** — shows + clocks (Program Director home)
+6. **Logs** — renamed from "Playlists"; chronological daily logs
+7. **Templates** — labelled "Default Clocks" eventually; unchanged for now
+8. Users, Analytics, System Logs, Settings, Billing, Roles, Profile
+
+---
+
+## Personas & journeys
+
+All three personas land on `/today`.
+
+### Persona A — Program Director (setup loop)
+
+**Goal**: make sure every hour of the week is owned by a Program with a tuned Clock.
+
+1. Opens `/today`. Sees a 24-hour timeline with colored Program bands and a grey **"Uncovered 18:00–22:00"** band.
+2. Clicks the uncovered band → `/programs/new?start_hour=18&end_hour=22` (query pre-fills form).
+3. Names the show, picks a color, days, assigns (or creates) a Clock → saves.
+4. Lands on `/programs/:id/clock`, edits slots, saves.
+5. Returns to `/today`; the grey band is now colored. Done.
+
+### Persona B — Music Director (rotation loop)
+
+**Goal**: tune category rotation so no song is overplayed within a daypart.
+
+1. `/today` → clicks "Today's Log" → `/playlists/:id` with program bands overlaid on the hour grid.
+2. Notices the Morning Rush band shows a warning icon (from Analytics: category overplayed).
+3. Clicks the band → jumps to `/programs/:id/clock` to retune slot categories.
+4. Back to `/library` if songs need recategorization.
+
+### Persona C — Board-op / on-air operator (daily loop)
+
+**Goal**: know what's on air now, grab today's log, print or export.
+
+1. `/today` → sees **Now Playing** card (current hour → active Program → current clock slot), **Next Up** card, and a prominent "Open today's log" button.
+2. Clicks "Open today's log" → `/playlists/:id` with bands.
+3. Reviews, approves, exports XLSX.
+
+---
+
+## Scope of the initial PR (navigational skeleton)
+
+This PR ships the IA + empty states. It does **not** change the generation engine.
+
+Files touched:
+
+- `frontend/src/app/today/page.tsx` — NEW landing
+- `frontend/src/components/ClientLayout.tsx` — add Today, rename Playlists→Logs
+- `frontend/src/app/playlists/page.tsx` — H1 "Station Logs"
+- `frontend/src/app/playlists/[id]/page.tsx` — program-band overlay on the hour grid
+- `frontend/src/app/programs/[id]/episodes/page.tsx` — "Open in Log" link copy
+- `e2e/programs-journey.mjs` — extends happy path to assert the `/today` data surface (today's playlist fetch via existing month endpoint)
+
+## Out of scope (tracked as GitHub issues)
+
+See the issues labelled `epic:programs-logs-unification`. Each ticket below is filed alongside this PR:
+
+| ID | Priority | Title |
+|----|----|----|
+| T-A | P0 | Clocks drive playlist generation (`programs.default_clock_id`) |
+| T-B | P0 | `GET /stations/:sid/playlists?date=YYYY-MM-DD` filter |
+| T-C | P1 | Generate-day-from-Programs orchestration route |
+| T-D | P1 | WebSocket/SSE now-playing channel (replaces polling) |
+| T-E | P2 | Templates → "Default Clocks" copy + redirect pass |
+| T-F | P2 | Log → Program backlink in Log header |
+| T-G | P2 | `GET /playlists/:id/episodes` reverse endpoint |
+| T-H | P2 | `useProgramCoverage(stationId, date)` hook + tests |
+| T-I | P2 | DJ profile surfaced on Today's Now Playing card |
+| T-J | P3 | Mobile responsive polish for `/today` |
+| T-K | P3 | Timeline multi-day view (`?span=3`) |
+| T-L | P3 | Coverage-gap auto-fix CTA |
+| T-M | P3 | Archive old `user-journey-programs.md` |
+| T-N | P3 | Gate `/playlists/new` manual creation behind advanced flag |
+
+---
+
+## Acceptance checklist (every ticket in this epic)
+
+- [ ] Change is consistent with the mental model above
+- [ ] This user journey doc is updated if the flow changes
+- [ ] `e2e/programs-journey.mjs` extended if a new flow is introduced
+- [ ] `pnpm run typecheck && pnpm run lint && pnpm run test:unit` all green locally before push
+- [ ] Smoke-tested manually against `docker-compose up` stack

--- a/e2e/programs-journey.mjs
+++ b/e2e/programs-journey.mjs
@@ -157,8 +157,22 @@ async function main() {
   assert(putRes.status === 200, 'PUT /programs/:id returns 200', putRes);
   assert(putRes.data?.name?.endsWith('(edited)'), 'update persists name change');
 
-  // Step 11 — delete program (non-default, should succeed)
+  // Step 11 — /today data surface: fetch the current month's playlists
+  // for the station, which is what the /today page uses to find "today's log".
+  // No dedicated ?date= endpoint exists yet (see ticket T-B); /today filters
+  // the month response client-side, so this asserts the same surface.
   step = 11;
+  const monthKey2 = new Date().toISOString().slice(0, 7);
+  const todayPlaylists = await api(`/api/v1/stations/${station.id}/playlists?month=${monthKey2}`);
+  assert(
+    todayPlaylists.status === 200,
+    'GET /stations/:sid/playlists?month=YYYY-MM returns 200 (powers /today)',
+    todayPlaylists,
+  );
+  assert(Array.isArray(todayPlaylists.data), 'month playlists response is an array');
+
+  // Step 12 — delete program (non-default, should succeed)
+  step = 12;
   const delRes = await api(`/api/v1/programs/${program.id}`, { method: 'DELETE' });
   assert(delRes.status === 204, 'DELETE /programs/:id returns 204', delRes);
 

--- a/frontend/src/app/playlists/[id]/page.tsx
+++ b/frontend/src/app/playlists/[id]/page.tsx
@@ -56,6 +56,21 @@ interface Song {
   category_id: string;
 }
 
+// Minimal subset of Program we need for the band overlay on the Log header.
+// See docs/user-journey-programs-logs.md.
+interface LogProgramBand {
+  id: string;
+  name: string;
+  active_days: string[];
+  start_hour: number;
+  end_hour: number;
+  color_tag: string | null;
+  is_active: boolean;
+  is_default: boolean;
+}
+
+const DAY_NAMES_OVERLAY = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
 const STATUS_STYLES: Record<PlaylistStatus, string> = {
   draft: 'bg-gray-800 text-gray-400',
   generating: 'bg-blue-900/30 text-blue-400 animate-pulse',
@@ -98,6 +113,7 @@ export default function PlaylistDetailPage() {
   const [generationProgress, setGenerationProgress] = useState<{ pct: number; step: string }>({ pct: 0, step: '' });
   const [stationAutoApprove, setStationAutoApprove] = useState(false);
   const [musicWidgetEntryId, setMusicWidgetEntryId] = useState<string | null>(null);
+  const [stationPrograms, setStationPrograms] = useState<LogProgramBand[]>([]);
   const djPlayer = useDjPlayer();
 
   const fetchDjScript = useCallback(async () => {
@@ -277,6 +293,14 @@ export default function PlaylistDetailPage() {
         } catch {
           // Non-critical — fall back to false
         }
+        // Fetch programs for the station so we can render which Program owns
+        // each hour of this log. See user-journey-programs-logs.md §overlay.
+        try {
+          const progs = await api.get<LogProgramBand[]>(`/api/v1/stations/${pl.station_id}/programs`);
+          setStationPrograms(progs);
+        } catch {
+          setStationPrograms([]);
+        }
       }
     } catch (err: unknown) {
       setError((err as ApiError).message ?? 'Failed to load playlist');
@@ -374,7 +398,7 @@ export default function PlaylistDetailPage() {
       <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
         <div className="flex items-center gap-4">
           <Link href="/playlists" className="text-sm text-gray-500 hover:text-gray-300 transition-colors">
-            ← Playlists
+            ← Logs
           </Link>
           <div>
             <h1 className="text-xl font-bold text-white">
@@ -444,6 +468,11 @@ export default function PlaylistDetailPage() {
         <div className="mb-4 bg-red-900/30 border border-red-700/50 text-red-400 px-4 py-3 rounded-lg text-sm">
           {error}
         </div>
+      )}
+
+      {/* Program band overlay — which Program owns which hour of this log */}
+      {playlist && stationPrograms.length > 0 && (
+        <ProgramBandOverlay programs={stationPrograms} date={playlist.date} />
       )}
 
       {/* Tab bar */}
@@ -769,6 +798,71 @@ export default function PlaylistDetailPage() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ── Program band overlay ─────────────────────────────────────────────────────
+// Renders a 24-hour strip showing which Program covers each hour of this Log.
+// Each band links to its program's clock editor. Uncovered hours show a neutral
+// "Default clock" label and link to the new-program form. See T-F / T-G follow-up
+// tickets for a proper reverse Log→Episode query.
+
+function ProgramBandOverlay({ programs, date }: { programs: LogProgramBand[]; date: string }) {
+  const weekday = DAY_NAMES_OVERLAY[new Date(date.slice(0, 10) + 'T00:00:00').getDay()];
+
+  function ownerOfHour(hour: number): LogProgramBand | null {
+    for (const p of programs) {
+      if (!p.is_active || p.is_default) continue;
+      if (!p.active_days.includes(weekday)) continue;
+      if (hour >= p.start_hour && hour < p.end_hour) return p;
+    }
+    return null;
+  }
+
+  interface OverlayBand { program: LogProgramBand | null; start: number; end: number }
+  const bands: OverlayBand[] = [];
+  let cursor = 0;
+  while (cursor < 24) {
+    const owner = ownerOfHour(cursor);
+    let end = cursor + 1;
+    while (end < 24 && ownerOfHour(end)?.id === owner?.id) end++;
+    bands.push({ program: owner, start: cursor, end });
+    cursor = end;
+  }
+
+  return (
+    <div className="mb-4">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Programs airing {weekday}
+        </span>
+        <span className="text-[10px] text-gray-600">Click a band to edit its clock</span>
+      </div>
+      <div className="flex h-8 rounded-lg overflow-hidden bg-[#12122a] border border-[#2a2a40]">
+        {bands.map((band, i) => {
+          const widthPct = ((band.end - band.start) / 24) * 100;
+          const bg = band.program?.color_tag ?? '#1e1e2e';
+          const label = band.program?.name ?? 'Default clock';
+          const href = band.program ? `/programs/${band.program.id}/clock` : '/programs/new';
+          const title = band.program
+            ? `${band.program.name} (${band.start}:00–${band.end}:00)`
+            : `No program covers ${band.start}:00–${band.end}:00`;
+          return (
+            <Link
+              key={i}
+              href={href}
+              title={title}
+              style={{ width: `${widthPct}%`, backgroundColor: bg }}
+              className={`h-full flex items-center justify-center text-[10px] font-medium truncate px-1 hover:opacity-80 transition-opacity ${
+                band.program ? 'text-white' : 'text-gray-600 border-r border-dashed border-[#2a2a40] last:border-r-0'
+              }`}
+            >
+              <span className="truncate">{label}</span>
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/playlists/page.tsx
+++ b/frontend/src/app/playlists/page.tsx
@@ -288,7 +288,10 @@ export default function PlaylistsPage() {
     <div className="p-6 md:p-8">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-xl md:text-2xl font-bold text-white">Playlists</h1>
+        <div>
+          <h1 className="text-xl md:text-2xl font-bold text-white">Station Logs</h1>
+          <p className="text-gray-500 text-xs mt-0.5">Daily airtime logs · one per station per day</p>
+        </div>
         <button
           onClick={handleGenerateMonth}
           disabled={!selectedStation || generating}

--- a/frontend/src/app/programs/[id]/episodes/page.tsx
+++ b/frontend/src/app/programs/[id]/episodes/page.tsx
@@ -83,8 +83,8 @@ export default function EpisodesPage() {
         <div className="text-center py-16 text-gray-500">
           <p className="text-lg mb-2">No episodes yet</p>
           <p className="text-sm">
-            Episodes are created automatically when you generate a playlist for this program&apos;s station.
-            Head to <Link href="/playlists" className="text-violet-400 hover:underline">Playlists</Link> to generate one.
+            Episodes are created automatically when you generate a log for this program&apos;s station.
+            Head to <Link href="/playlists" className="text-violet-400 hover:underline">Logs</Link> to generate one.
           </p>
         </div>
       ) : (
@@ -103,7 +103,7 @@ export default function EpisodesPage() {
               <div className="flex items-center gap-3 text-sm shrink-0">
                 {ep.playlist_id && (
                   <Link href={`/playlists/${ep.playlist_id}`} className="text-blue-400 hover:text-blue-300">
-                    Playlist
+                    Open in Log
                   </Link>
                 )}
                 {ep.dj_script_id && (

--- a/frontend/src/app/today/page.tsx
+++ b/frontend/src/app/today/page.tsx
@@ -1,0 +1,415 @@
+'use client';
+
+/**
+ * /today — unified landing for Program Directors, Music Directors, and Board Ops.
+ *
+ * See docs/user-journey-programs-logs.md for the rationale. This is the navigational
+ * skeleton: it uses existing endpoints only (no schema or engine changes). Follow-up
+ * tickets add the now-playing WebSocket, generate-day orchestration, and reverse
+ * log→program query.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { getCurrentUser } from '@/lib/auth';
+import { api } from '@/lib/api';
+
+interface Station {
+  id: string;
+  name: string;
+}
+
+interface Program {
+  id: string;
+  station_id: string;
+  name: string;
+  description: string | null;
+  active_days: string[];
+  start_hour: number;
+  end_hour: number;
+  color_tag: string | null;
+  is_active: boolean;
+  is_default: boolean;
+}
+
+interface Playlist {
+  id: string;
+  date: string;
+  status: 'draft' | 'generating' | 'ready' | 'approved' | 'exported' | 'failed';
+  station_id: string;
+}
+
+const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+
+function todayISO(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function todayMonthKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function currentWeekday(): string {
+  return DAY_NAMES[new Date().getDay()];
+}
+
+function formatHour(h: number): string {
+  const hh = h % 24;
+  if (hh === 0) return '12 AM';
+  if (hh === 12) return '12 PM';
+  return hh < 12 ? `${hh} AM` : `${hh - 12} PM`;
+}
+
+/**
+ * Compute which program (if any) owns a given hour for the current weekday.
+ * Handles the simple non-wrapping case. end_hour is exclusive (e.g. 6-10 = 6,7,8,9).
+ */
+function programForHour(programs: Program[], weekday: string, hour: number): Program | null {
+  for (const p of programs) {
+    if (!p.is_active || p.is_default) continue;
+    if (!p.active_days.includes(weekday)) continue;
+    if (hour >= p.start_hour && hour < p.end_hour) return p;
+  }
+  return null;
+}
+
+interface Band {
+  program: Program | null;
+  startHour: number;
+  endHour: number;
+}
+
+function computeBands(programs: Program[], weekday: string): Band[] {
+  const bands: Band[] = [];
+  let cursor = 0;
+  while (cursor < 24) {
+    const owner = programForHour(programs, weekday, cursor);
+    let end = cursor + 1;
+    while (end < 24 && programForHour(programs, weekday, end)?.id === owner?.id) end++;
+    bands.push({ program: owner, startHour: cursor, endHour: end });
+    cursor = end;
+  }
+  return bands;
+}
+
+export default function TodayPage() {
+  const router = useRouter();
+  const [stations, setStations] = useState<Station[]>([]);
+  const [selectedStation, setSelectedStation] = useState('');
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [todayLog, setTodayLog] = useState<Playlist | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(() => new Date());
+
+  // Tick every 60s to refresh the Now Playing card cheaply.
+  useEffect(() => {
+    const i = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(i);
+  }, []);
+
+  useEffect(() => {
+    const user = getCurrentUser();
+    if (!user) {
+      router.push('/login');
+      return;
+    }
+    api.get<Station[]>(`/api/v1/companies/${user.company_id}/stations`)
+      .then((list) => {
+        setStations(list);
+        if (list.length > 0) setSelectedStation(list[0].id);
+        else setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [router]);
+
+  useEffect(() => {
+    if (!selectedStation) return;
+    setLoading(true);
+    const month = todayMonthKey();
+    const iso = todayISO();
+
+    Promise.all([
+      api.get<Program[]>(`/api/v1/stations/${selectedStation}/programs`).catch(() => []),
+      api.get<Playlist[]>(`/api/v1/stations/${selectedStation}/playlists?month=${month}`).catch(() => []),
+    ])
+      .then(([progs, logs]) => {
+        setPrograms(progs);
+        const match = logs.find((l) => l.date.slice(0, 10) === iso) ?? null;
+        setTodayLog(match);
+      })
+      .finally(() => setLoading(false));
+  }, [selectedStation]);
+
+  const weekday = currentWeekday();
+  const currentHour = now.getHours();
+  const bands = useMemo(() => computeBands(programs, weekday), [programs, weekday]);
+  const nowProgram = programForHour(programs, weekday, currentHour);
+  const gaps = bands.filter((b) => !b.program);
+  const namedPrograms = programs.filter((p) => !p.is_default);
+
+  // Next up: find the next band after the current hour that has a program
+  const nextBand = bands.find((b) => b.startHour > currentHour && b.program) ?? null;
+
+  const user = getCurrentUser();
+
+  return (
+    <div className="p-6 md:p-8 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Today</h1>
+          <p className="text-gray-500 text-sm mt-0.5">
+            {now.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
+            {' · '}
+            {now.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+          </p>
+        </div>
+        {stations.length > 1 && (
+          <select
+            value={selectedStation}
+            onChange={(e) => setSelectedStation(e.target.value)}
+            className="bg-[#1a1a2e] border border-[#2a2a40] text-gray-300 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-violet-500"
+          >
+            {stations.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-violet-500" />
+        </div>
+      ) : stations.length === 0 ? (
+        <EmptyState
+          title="No stations yet"
+          body="Programs and Logs live inside a station. Create one to get started."
+          cta={{ href: '/stations', label: 'Set up a station' }}
+        />
+      ) : namedPrograms.length === 0 ? (
+        <EmptyState
+          title="No programs scheduled"
+          body={`Define recurring shows like "Morning Rush" or "Afternoon Drive" to give ${user?.display_name ? 'your team' : 'the team'} a clear daily structure.`}
+          cta={{ href: '/programs/new', label: 'Create your first program' }}
+        />
+      ) : (
+        <div className="space-y-6">
+          {/* Now Playing + Next Up cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <NowPlayingCard program={nowProgram} hour={currentHour} stationId={selectedStation} />
+            <NextUpCard band={nextBand} />
+          </div>
+
+          {/* Timeline */}
+          <Timeline bands={bands} currentHour={currentHour} />
+
+          {/* Coverage gaps alert */}
+          {gaps.length > 0 && (
+            <GapAlert gaps={gaps} />
+          )}
+
+          {/* Today's log quick actions */}
+          <TodayLogCard log={todayLog} stationId={selectedStation} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Components ───────────────────────────────────────────────────────────────
+
+function EmptyState({ title, body, cta }: { title: string; body: string; cta: { href: string; label: string } }) {
+  return (
+    <div className="text-center py-20">
+      <div className="w-16 h-16 bg-violet-600/10 rounded-2xl flex items-center justify-center mx-auto mb-4">
+        <svg className="w-8 h-8 text-violet-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+      </div>
+      <h3 className="text-white font-semibold mb-2">{title}</h3>
+      <p className="text-gray-500 text-sm mb-6 max-w-sm mx-auto">{body}</p>
+      <Link href={cta.href} className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium px-5 py-2.5 rounded-lg transition-colors">
+        {cta.label}
+      </Link>
+    </div>
+  );
+}
+
+function NowPlayingCard({ program, hour, stationId }: { program: Program | null; hour: number; stationId: string }) {
+  const color = program?.color_tag ?? '#334155';
+  return (
+    <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">Now Playing</span>
+        <span className="text-xs text-gray-600">{formatHour(hour)}</span>
+      </div>
+      {program ? (
+        <>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
+            <h3 className="text-white font-semibold truncate">{program.name}</h3>
+          </div>
+          <p className="text-gray-500 text-xs mb-4">
+            {formatHour(program.start_hour)} – {formatHour(program.end_hour)}
+          </p>
+          <Link
+            href={`/programs/${program.id}/clock`}
+            className="inline-block text-xs text-violet-400 hover:text-violet-300 font-medium"
+          >
+            Open clock →
+          </Link>
+        </>
+      ) : (
+        <>
+          <p className="text-gray-400 text-sm mb-2">No program covers this hour.</p>
+          <Link href={`/programs/new`} className="text-xs text-violet-400 hover:text-violet-300 font-medium">
+            Schedule one →
+          </Link>
+        </>
+      )}
+      {/* stationId reserved for the T-I DJ profile + T-D SSE follow-up */}
+      <span className="sr-only" data-station={stationId} />
+    </div>
+  );
+}
+
+function NextUpCard({ band }: { band: Band | null }) {
+  return (
+    <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">Next Up</span>
+        {band && <span className="text-xs text-gray-600">{formatHour(band.startHour)}</span>}
+      </div>
+      {band?.program ? (
+        <>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: band.program.color_tag ?? '#7c3aed' }} />
+            <h3 className="text-white font-semibold truncate">{band.program.name}</h3>
+          </div>
+          <p className="text-gray-500 text-xs">
+            Airs {formatHour(band.startHour)} – {formatHour(band.endHour)}
+          </p>
+        </>
+      ) : (
+        <p className="text-gray-400 text-sm">Nothing else scheduled today.</p>
+      )}
+    </div>
+  );
+}
+
+function Timeline({ bands, currentHour }: { bands: Band[]; currentHour: number }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Today&apos;s Timeline</h2>
+        <span className="text-xs text-gray-600">Tap a band to jump to its program</span>
+      </div>
+      <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-4 overflow-hidden">
+        <div className="flex h-12 rounded-lg overflow-hidden">
+          {bands.map((band, i) => {
+            const widthPct = ((band.endHour - band.startHour) / 24) * 100;
+            const bg = band.program?.color_tag ?? '#1e1e2e';
+            const isCurrent = currentHour >= band.startHour && currentHour < band.endHour;
+            const inner = (
+              <div
+                className={`h-full flex items-center justify-center text-[10px] font-medium transition-opacity hover:opacity-80 ${
+                  band.program ? 'text-white' : 'text-gray-600 border border-dashed border-[#2a2a40]'
+                } ${isCurrent ? 'ring-2 ring-white/40 ring-inset' : ''}`}
+                style={{ width: `${widthPct}%`, backgroundColor: bg }}
+                title={band.program ? `${band.program.name} (${formatHour(band.startHour)}–${formatHour(band.endHour)})` : `Uncovered ${formatHour(band.startHour)}–${formatHour(band.endHour)}`}
+              >
+                <span className="truncate px-1">
+                  {band.program ? band.program.name : 'Uncovered'}
+                </span>
+              </div>
+            );
+            return band.program ? (
+              <Link key={i} href={`/programs/${band.program.id}/clock`} style={{ width: `${widthPct}%` }}>
+                {inner}
+              </Link>
+            ) : (
+              <Link key={i} href={`/programs/new`} style={{ width: `${widthPct}%` }}>
+                {inner}
+              </Link>
+            );
+          })}
+        </div>
+        <div className="flex justify-between mt-2 text-[10px] text-gray-600">
+          <span>12 AM</span>
+          <span>6 AM</span>
+          <span>12 PM</span>
+          <span>6 PM</span>
+          <span>12 AM</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GapAlert({ gaps }: { gaps: Band[] }) {
+  return (
+    <div className="bg-yellow-900/10 border border-yellow-700/30 rounded-xl px-4 py-3 flex items-start gap-3">
+      <svg className="w-5 h-5 text-yellow-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+      </svg>
+      <div className="flex-1">
+        <p className="text-sm text-yellow-200 font-medium">
+          {gaps.length === 1 ? '1 hour range' : `${gaps.length} hour ranges`} not covered by a program today
+        </p>
+        <p className="text-xs text-yellow-300/70 mt-1">
+          {gaps.map((g) => `${formatHour(g.startHour)}–${formatHour(g.endHour)}`).join(', ')}
+        </p>
+        <Link href="/programs/new" className="inline-block mt-2 text-xs text-yellow-300 hover:text-yellow-200 font-medium">
+          Schedule a program →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function TodayLogCard({ log, stationId }: { log: Playlist | null; stationId: string }) {
+  const STATUS_STYLES: Record<string, string> = {
+    draft: 'bg-gray-800 text-gray-400',
+    generating: 'bg-blue-900/30 text-blue-400',
+    ready: 'bg-yellow-900/30 text-yellow-400',
+    approved: 'bg-green-900/30 text-green-400',
+    exported: 'bg-violet-900/30 text-violet-400',
+    failed: 'bg-red-900/30 text-red-400',
+  };
+  return (
+    <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-5 flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">Today&apos;s Log</span>
+        {log ? (
+          <div className="flex items-center gap-3 mt-2">
+            <h3 className="text-white font-semibold">Station log ready</h3>
+            <span className={`text-xs px-2 py-0.5 rounded capitalize ${STATUS_STYLES[log.status] ?? ''}`}>{log.status}</span>
+          </div>
+        ) : (
+          <p className="text-gray-400 text-sm mt-2">No log generated yet for today.</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {log ? (
+          <Link
+            href={`/playlists/${log.id}`}
+            className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            Open today&apos;s log
+          </Link>
+        ) : (
+          <Link
+            href={`/playlists`}
+            className="bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            Generate log
+          </Link>
+        )}
+      </div>
+      <span className="sr-only" data-station={stationId} />
+    </div>
+  );
+}

--- a/frontend/src/components/ClientLayout.tsx
+++ b/frontend/src/components/ClientLayout.tsx
@@ -9,6 +9,14 @@ import { getCurrentUser } from '@/lib/auth';
 
 const NAV_LINKS = [
   {
+    href: '/today', label: 'Today',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+    ),
+  },
+  {
     href: '/dashboard', label: 'Dashboard',
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -49,7 +57,7 @@ const NAV_LINKS = [
     ),
   },
   {
-    href: '/playlists', label: 'Playlists',
+    href: '/playlists', label: 'Logs',
     icon: (
       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 6h16M4 10h16M4 14h10"/>


### PR DESCRIPTION
## Summary

Ships the navigational skeleton for the **Programs ↔ Logs unification** — the new mental model described in `docs/user-journey-programs-logs.md`. PlayGen currently has two parallel entry points (Programs with clocks that don't drive generation, Playlists/Logs from Templates). This PR aligns the UI with the industry convention used by RCS GSelector / Music Master / PowerGold:

> **Station Log** ← composed of **Program bands** ← each owning a **Clock** ← populated from the **Library**

No schema change, no generation-engine change. Just IA, empty states, and backlinks so the existing data model finally surfaces the right way.

### What ships
- **`docs/user-journey-programs-logs.md`** — new source-of-truth journey doc with three personas (Program Director, Music Director, Board Op) and the full epic ticket table.
- **`/today` landing page** — Now Playing + Next Up cards, 24-hour Program timeline, coverage-gap alert, Today's Log card. Uses existing endpoints only.
- **Sidebar**: Today nav added at top, Playlists renamed to **Logs**.
- **Log detail page**: new **Program-band overlay** showing which Program owns each hour of the day; bands link to their clock editor.
- **Station Logs** H1 with subtitle on `/playlists`.
- **"Open in Log"** link on Program episodes.
- **E2E**: `programs-journey.mjs` extended to assert the `/today` data surface.

### Out of scope (tracked)
Epic follow-ups filed as issues `T-A..T-N` labelled `epic:programs-logs-unification`. Highlights:
- **T-A [P0]** Clocks drive generation
- **T-B [P0]** `GET /stations/:sid/playlists?date=` filter
- **T-C [P1]** Generate-day-from-Programs orchestration route
- **T-D [P1]** WebSocket/SSE now-playing channel

## Test plan
- [x] `pnpm run typecheck` — all workspaces green
- [x] `pnpm run lint` — clean
- [x] `pnpm run test:unit` — all suites green (auth/analytics/dj/station/scheduler/library)
- [ ] Manual smoke: `docker-compose up -d` → log in → verify `/today` renders, coverage gap appears with no programs, band overlay appears on `/playlists/:id` after a program is created
- [ ] `node e2e/programs-journey.mjs` against local stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)