### PR TITLE
feat(docs): archive user-journey-programs.md → docs/archive/ (closes #303)

### DIFF
--- a/docs/archive/user-journey-programs.md
+++ b/docs/archive/user-journey-programs.md
@@ -1,4 +1,11 @@
-# User Journey — Programs
+# User Journey — Programs (archived)
+
+> **Moved**: This document has been archived. The canonical reference is now
+> [`docs/user-journey-programs-logs.md`](../user-journey-programs-logs.md), which
+> supersedes this file with the unified Programs + Logs mental model.
+> See GitHub issue #303 for context.
+
+---
 
 > **Purpose**: end-to-end walkthrough of the *Program → Show Clock → Episode → Playlist/DJ Script* flow, as a staff UX + engineering reference and as the script for manual QA.
 >


### PR DESCRIPTION
## Summary
- Moves `docs/user-journey-programs.md` to `docs/archive/` per T-M (#303)
- Adds redirect note at top of archived file pointing to canonical `docs/user-journey-programs-logs.md`
- No code changes — docs-only

## Test plan
- [ ] Verify `docs/archive/user-journey-programs.md` exists with redirect header
- [ ] Verify `docs/user-journey-programs.md` is gone at root level
- [ ] `pnpm run typecheck && pnpm run lint && pnpm run test:unit` — no code touched, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)