### PR TITLE
feat(frontend): mobile responsive polish for /today (closes #300)

### DIFF
--- a/frontend/src/app/today/page.tsx
+++ b/frontend/src/app/today/page.tsx
@@ -200,7 +200,9 @@ export default function TodayPage() {
         <div className="space-y-6">
           {/* Now Playing + Next Up cards */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <NowPlayingCard program={nowProgram} hour={currentHour} stationId={selectedStation} />
+            <div className="sticky top-0 z-10 md:static">
+              <NowPlayingCard program={nowProgram} hour={currentHour} stationId={selectedStation} />
+            </div>
             <NextUpCard band={nextBand} />
           </div>
 
@@ -306,10 +308,12 @@ function Timeline({ bands, currentHour }: { bands: Band[]; currentHour: number }
     <div>
       <div className="flex items-center justify-between mb-2">
         <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Today&apos;s Timeline</h2>
-        <span className="text-xs text-gray-600">Tap a band to jump to its program</span>
+        <span className="hidden sm:block text-xs text-gray-600">Tap a band to jump to its program</span>
       </div>
-      <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-4 overflow-hidden">
-        <div className="flex h-12 rounded-lg overflow-hidden">
+      <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-4">
+        <div className="overflow-x-auto">
+          <div className="min-w-[520px]">
+            <div className="flex h-12 rounded-lg overflow-hidden">
           {bands.map((band, i) => {
             const widthPct = ((band.endHour - band.startHour) / 24) * 100;
             const bg = band.program?.color_tag ?? '#1e1e2e';
@@ -338,12 +342,14 @@ function Timeline({ bands, currentHour }: { bands: Band[]; currentHour: number }
             );
           })}
         </div>
-        <div className="flex justify-between mt-2 text-[10px] text-gray-600">
-          <span>12 AM</span>
-          <span>6 AM</span>
-          <span>12 PM</span>
-          <span>6 PM</span>
-          <span>12 AM</span>
+            <div className="flex justify-between mt-2 text-[10px] text-gray-600">
+              <span>12 AM</span>
+              <span>6 AM</span>
+              <span>12 PM</span>
+              <span>6 PM</span>
+              <span>12 AM</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -15,10 +15,11 @@ Before starting any task, an agent MUST:
 ## Next Recommended Tickets
 
 ### For ticket-bug workers (P0 first)
-_(#244–#247 resolved — check GitHub Issues for new P0/P1 bugs)_
+_(no open bugs — all P0/P1 bugs resolved as of 2026-04-12)_
 
 ### For ticket-feat worker
-_(no open recommended tickets — check GitHub Issues for new work)_
+- **#293** T-C: Generate-day-from-Programs orchestration route [P1] — backend route, unclaimed, ready to start
+- **#294** T-D: WebSocket/SSE now-playing channel for /today [P1] — real-time feature, unclaimed
 
 ---
 

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,9 +24,10 @@ _(no open bugs — all P0/P1 bugs resolved as of 2026-04-12)_
 ---
 
 ## Active Work
-- [ ] feat(frontend): mobile polish /today - sticky NowPlaying + timeline scroll (#300, feat/issue-300) | @claude-code | 2026-04-12
+_(none)_
 
 ## Recently Completed
+- [x] feat(frontend): mobile responsive polish for /today — sticky NowPlaying + timeline scroll (#300, PR #350) | @claude-code | 2026-04-12
 - [x] fix(frontend): Docker server.js standalone layout fix + docs (#246, PR #341) | @claude-code | 2026-04-09
 - [x] fix(auth): lazy-init Resend — no crash on missing RESEND_API_KEY (#245, PR #340) | @claude-code | 2026-04-09
 - [x] fix(gateway): document programs routes in api-spec.md + gateway smoke test (#244, PR #343) | @claude-code | 2026-04-09

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,7 +24,7 @@ _(no open bugs — all P0/P1 bugs resolved as of 2026-04-12)_
 ---
 
 ## Active Work
-_(none)_
+- [ ] feat(frontend): mobile polish /today - sticky NowPlaying + timeline scroll (#300, feat/issue-300) | @claude-code | 2026-04-12
 
 ## Recently Completed
 - [x] fix(frontend): Docker server.js standalone layout fix + docs (#246, PR #341) | @claude-code | 2026-04-09


### PR DESCRIPTION
## Summary
- Timeline now scrolls horizontally on mobile (`overflow-x-auto` + `min-w-[520px]`) — 375px viewports no longer squish 24 program bands into an unreadable strip
- Now Playing card is `sticky top-0 z-10` on mobile, `md:static` on desktop — stays visible as user scrolls through the timeline and log sections
- "Tap a band" hint text hidden on xs screens (`hidden sm:block`) to reclaim space

## Acceptance criteria
- [x] Implementation matches the mental model in docs/user-journey-programs-logs.md
- [x] User journey doc unchanged (no flow changes, CSS-only)
- [x] e2e/programs-journey.mjs unchanged (no new flow added)
- [x] pnpm run typecheck + lint + test:unit green locally
- [ ] Smoke-tested against docker-compose up stack

## Test plan
- [ ] Open /today at 375px viewport width (Chrome DevTools mobile emulation)
- [ ] Confirm timeline bar scrolls horizontally rather than squishing text
- [ ] Scroll down page — confirm Now Playing card sticks to top on mobile
- [ ] Confirm at md+ breakpoint (≥768px) Now Playing card is not sticky (normal flow)
- [ ] Confirm "Tap a band" hint hidden on xs, visible on sm+

🤖 Generated with [Claude Code](https://claude.ai/claude-code)