### PR TITLE
feat(station+frontend): DJ profile on Today's Now Playing card (closes #299)

### DIFF
--- a/docs/user-journey-programs-logs.md
+++ b/docs/user-journey-programs-logs.md
@@ -83,7 +83,7 @@ All three personas land on `/today`.
 
 **Goal**: know what's on air now, grab today's log, print or export.
 
-1. `/today` → sees **Now Playing** card (current hour → active Program → current clock slot), **Next Up** card, and a prominent "Open today's log" button.
+1. `/today` → sees **Now Playing** card (current hour → active Program → DJ avatar/name if assigned → current clock slot), **Next Up** card, and a prominent "Open today's log" button. The DJ badge links to `/stations/:sid/dj`.
 2. Clicks "Open today's log" → `/playlists/:id` with bands.
 3. Reviews, approves, exports XLSX.
 
@@ -116,7 +116,7 @@ See the issues labelled `epic:programs-logs-unification`. Each ticket below is f
 | T-F | P2 | Log → Program backlink in Log header |
 | T-G | P2 | `GET /playlists/:id/episodes` reverse endpoint |
 | T-H | P2 | `useProgramCoverage(stationId, date)` hook + tests |
-| T-I | P2 | DJ profile surfaced on Today's Now Playing card |
+| T-I | P2 | ~~DJ profile surfaced on Today's Now Playing card~~ (done — #299) |
 | T-J | P3 | Mobile responsive polish for `/today` |
 | T-K | P3 | Timeline multi-day view (`?span=3`) |
 | T-L | P3 | Coverage-gap auto-fix CTA |

--- a/e2e/programs-journey.mjs
+++ b/e2e/programs-journey.mjs
@@ -156,6 +156,8 @@ async function main() {
   });
   assert(putRes.status === 200, 'PUT /programs/:id returns 200', putRes);
   assert(putRes.data?.name?.endsWith('(edited)'), 'update persists name change');
+  // T-I: dj_profile_id column must be present (null when no DJ assigned)
+  assert('dj_profile_id' in (putRes.data ?? {}), 'program response includes dj_profile_id field (T-I: DJ profile on Now Playing)');
 
   // Step 11 — /today data surface: fetch the current month's playlists
   // for the station, which is what the /today page uses to find "today's log".

--- a/frontend/src/app/today/page.tsx
+++ b/frontend/src/app/today/page.tsx
@@ -9,7 +9,7 @@
  * log→program query.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { getCurrentUser } from '@/lib/auth';
@@ -29,6 +29,7 @@ interface Program {
   start_hour: number;
   end_hour: number;
   color_tag: string | null;
+  dj_profile_id: string | null;
   is_active: boolean;
   is_default: boolean;
 }
@@ -241,8 +242,30 @@ function EmptyState({ title, body, cta }: { title: string; body: string; cta: { 
   );
 }
 
+function djInitials(name: string): string {
+  return name.split(' ').slice(0, 2).map((w) => w[0] ?? '').join('').toUpperCase();
+}
+
 function NowPlayingCard({ program, hour, stationId }: { program: Program | null; hour: number; stationId: string }) {
   const color = program?.color_tag ?? '#334155';
+  const [djName, setDjName] = useState<string | null>(null);
+  const fetchedProfileId = useRef<string | null>(null);
+
+  useEffect(() => {
+    const profileId = program?.dj_profile_id ?? null;
+    if (!profileId) {
+      setDjName(null);
+      fetchedProfileId.current = null;
+      return;
+    }
+    // Avoid redundant fetches when program changes but dj_profile_id stays the same
+    if (fetchedProfileId.current === profileId) return;
+    fetchedProfileId.current = profileId;
+    api.get<{ id: string; name: string }>(`/api/v1/dj/profiles/${profileId}`)
+      .then((p) => setDjName(p.name))
+      .catch(() => setDjName(null));
+  }, [program?.dj_profile_id]);
+
   return (
     <div className="bg-[#1a1a2e] border border-[#2a2a40] rounded-xl p-5">
       <div className="flex items-center justify-between mb-3">
@@ -255,9 +278,20 @@ function NowPlayingCard({ program, hour, stationId }: { program: Program | null;
             <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: color }} />
             <h3 className="text-white font-semibold truncate">{program.name}</h3>
           </div>
-          <p className="text-gray-500 text-xs mb-4">
+          <p className="text-gray-500 text-xs mb-3">
             {formatHour(program.start_hour)} – {formatHour(program.end_hour)}
           </p>
+          {djName && (
+            <Link
+              href={`/stations/${stationId}/dj`}
+              className="flex items-center gap-2 mb-3 text-xs text-gray-400 hover:text-gray-200 transition-colors group"
+            >
+              <div className="w-6 h-6 rounded-full bg-violet-600/20 flex items-center justify-center text-[10px] font-bold text-violet-300 flex-shrink-0 group-hover:bg-violet-600/30">
+                {djInitials(djName)}
+              </div>
+              <span className="truncate">{djName}</span>
+            </Link>
+          )}
           <Link
             href={`/programs/${program.id}/clock`}
             className="inline-block text-xs text-violet-400 hover:text-violet-300 font-medium"
@@ -273,8 +307,6 @@ function NowPlayingCard({ program, hour, stationId }: { program: Program | null;
           </Link>
         </>
       )}
-      {/* stationId reserved for the T-I DJ profile + T-D SSE follow-up */}
-      <span className="sr-only" data-station={stationId} />
     </div>
   );
 }

--- a/services/station/src/services/programService.ts
+++ b/services/station/src/services/programService.ts
@@ -58,10 +58,11 @@ export async function updateProgram(
     end_hour: number;
     template_id: string | null;
     color_tag: string | null;
+    dj_profile_id: string | null;
     is_active: boolean;
   }>
 ): Promise<Program | null> {
-  const allowed = ['name', 'description', 'active_days', 'start_hour', 'end_hour', 'template_id', 'color_tag', 'is_active'] as const;
+  const allowed = ['name', 'description', 'active_days', 'start_hour', 'end_hour', 'template_id', 'color_tag', 'dj_profile_id', 'is_active'] as const;
   const fields: string[] = [];
   const values: unknown[] = [];
   let i = 1;

--- a/shared/db/src/migrations/056_add_dj_profile_id_to_programs.sql
+++ b/shared/db/src/migrations/056_add_dj_profile_id_to_programs.sql
@@ -1,0 +1,7 @@
+-- T-I: DJ profile on Today's Now Playing card (issue #299)
+-- Allows a program to declare which DJ profile hosts its hours,
+-- surfaced in the /today Now Playing card.
+ALTER TABLE programs
+  ADD COLUMN dj_profile_id UUID REFERENCES dj_profiles(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN programs.dj_profile_id IS 'Optional DJ profile that hosts this program. Displayed on the /today Now Playing card (T-I).';

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -618,6 +618,7 @@ export interface Program {
   end_hour: number;
   template_id: string | null;
   color_tag: string | null;
+  dj_profile_id: string | null;
   is_active: boolean;
   is_default: boolean;
   created_at: Date;

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -15,19 +15,18 @@ Before starting any task, an agent MUST:
 ## Next Recommended Tickets
 
 ### For ticket-bug workers (P0 first)
-_(no open bugs — all P0/P1 bugs resolved as of 2026-04-12)_
+_(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 
 ### For ticket-feat worker
-- **#293** T-C: Generate-day-from-Programs orchestration route [P1] — backend route, unclaimed, ready to start
-- **#294** T-D: WebSocket/SSE now-playing channel for /today [P1] — real-time feature, unclaimed
+1. **#293** — T-C: Generate-day-from-Programs orchestration route (P1, epic:programs-logs-unification)
+2. **#294** — T-D: WebSocket/SSE now-playing channel for /today (P1, epic:programs-logs-unification)
 
 ---
 
 ## Active Work
-_(none)_
+- [ ] feat(station+frontend): DJ profile on Today's Now Playing card (#299, feat/issue-299) | @claude-code | 2026-04-13 | Migration: 056
 
 ## Recently Completed
-- [x] feat(frontend): mobile responsive polish for /today — sticky NowPlaying + timeline scroll (#300, PR #350) | @claude-code | 2026-04-12
 - [x] fix(frontend): Docker server.js standalone layout fix + docs (#246, PR #341) | @claude-code | 2026-04-09
 - [x] fix(auth): lazy-init Resend — no crash on missing RESEND_API_KEY (#245, PR #340) | @claude-code | 2026-04-09
 - [x] fix(gateway): document programs routes in api-spec.md + gateway smoke test (#244, PR #343) | @claude-code | 2026-04-09


### PR DESCRIPTION
## Summary
- Add `dj_profile_id UUID` column to `programs` table (migration 056, FK → `dj_profiles`)
- Surface DJ name + avatar initials on the `/today` Now Playing card, linking to `/stations/:sid/dj`
- Allow setting `dj_profile_id` via `PUT /programs/:id`
- Extend e2e test to assert `dj_profile_id` field presence
- Update user journey doc: mark T-I done, add DJ badge to Persona C flow

## Test plan
- [x] `pnpm run typecheck` — all workspaces pass
- [x] `pnpm run lint` — clean
- [x] `pnpm run test:unit` — 318 tests pass (all 8 suites)
- [ ] Smoke-test: `docker-compose up`, run migration 056, assign a DJ profile to a program, verify Now Playing card shows DJ name
- [ ] Verify null `dj_profile_id` programs show no DJ badge