### PR TITLE
feat: daily program generation, playout engine, audio sourcing

### DIFF
--- a/docs/daily-program-2026-04-22.md
+++ b/docs/daily-program-2026-04-22.md
@@ -1,0 +1,447 @@
+# OwnRadio Daily Program — Wednesday, April 22, 2026
+
+**Station:** OwnRadio
+**Format:** Full Day (6:00 AM — 6:00 PM)
+**DJ Persona:** Alex (energetic, warm, community-focused)
+**Weather:** New York — Light drizzle, 8°C / 46°F, Humidity 71%, Wind 18.5 kph
+
+---
+
+## Station ID
+
+> "You're locked in to OwnRadio — your music, your vibe, your station. Broadcasting live and streaming worldwide at ownradio.app. Stay tuned, stay connected."
+
+---
+
+## HOUR 1 — Morning Wake-Up (6:00 AM – 7:00 AM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | *"Good morning! You're listening to OwnRadio..."* |
+| 01 | DJ Open | **Script below** |
+| 03 | Song | **Power** — Category: Hot Current |
+| 07 | Song | **Power** — Category: Hot Current |
+| 11 | Song | **Recurrent** — Category: Recurrent Hit |
+| 15 | Weather | **Script below** |
+| 16 | Song | **Power** — Category: Hot Current |
+| 20 | Song | **Gold** — Category: Gold Classic |
+| 24 | Ad Break | Sample Ad #1: Local Coffee Shop |
+| 25 | Song | **Hot Current** |
+| 29 | Song | **Recurrent** |
+| 33 | DJ Segment | Song intro / music fact |
+| 34 | Song | **Power** |
+| 38 | Song | **Gold** |
+| 42 | News | **Morning Headlines** (script below) |
+| 45 | Song | **Hot Current** |
+| 49 | Song | **Recurrent** |
+| 53 | Ad Break | Sample Ad #2: OwnRadio App Promo |
+| 54 | Song | **Power** |
+| 58 | DJ Close | Hour wrap + tease next hour |
+
+### DJ Open Script (6:00 AM)
+
+> "Good morning, OwnRadio fam! It's Wednesday, April 22nd — we made it to the middle of the week! I'm Alex, and I'm here to get your day started right. It's a little drizzly out there in New York — 8 degrees, so grab that jacket and that coffee. We've got a stacked lineup this morning — new hits, your favorites, and the headlines you need to know. Let's kick it off!"
+
+### Weather Script (6:15 AM)
+
+> "Quick weather check for you — right now it's 8 degrees Celsius, that's about 46 Fahrenheit, with some light drizzle moving through. Humidity sitting at 71 percent, winds at about 18 clicks an hour. Might want to keep that umbrella handy today. We'll update you again at the top of the next hour."
+
+### Morning News Headlines (6:42 AM)
+
+> "Time for your OwnRadio Morning Minute — here's what's making news:
+>
+> In tech — AI continues to reshape the workplace as companies roll out new automation tools. Reuters and WIRED both reporting major announcements expected this week from Silicon Valley.
+>
+> In entertainment — Billboard's latest charts are shaking up with fresh entries. We'll be spinning some of those tracks later today.
+>
+> On the world stage — check AP News and BBC for developing stories we're following. We'll have a full update at noon.
+>
+> That's your Morning Minute on OwnRadio."
+
+---
+
+## HOUR 2 — Morning Drive (7:00 AM – 8:00 AM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | Quick station ID jingle |
+| 01 | DJ Open | Energy check-in, tease joke |
+| 03 | Song | **Power** |
+| 07 | Song | **Hot Current** |
+| 11 | Song | **Recurrent** |
+| 15 | Joke | **Joke of the Morning** |
+| 16 | Song | **Power** |
+| 20 | Song | **Gold** |
+| 24 | Ad Break | Sample Ad #3: Fitness Studio |
+| 25 | Song | **Hot Current** |
+| 29 | Song | **Power** |
+| 33 | Shoutout | **Morning Shoutouts** |
+| 35 | Song | **Recurrent** |
+| 39 | Song | **Gold** |
+| 43 | Song | **Hot Current** |
+| 47 | DJ Segment | Music trivia / artist spotlight |
+| 49 | Song | **Power** |
+| 53 | Ad Break | Sample Ad #4: Tech Gadget |
+| 54 | Song | **Hot Current** |
+| 58 | DJ Close | *"Keep it here on OwnRadio..."* |
+
+### Joke of the Morning (7:15 AM)
+
+> "Alright, it's joke time — you ready? Here we go:
+>
+> Eight bytes walk into a bar. The bartender asks, 'Can I get you anything?' 'Yeah,' reply the bytes. 'Make us a double.'
+>
+> *laughs* Hey, we're a tech-forward station, what can I say! If you've got a better one, hit us up in the chat at ownradio.app."
+
+### Morning Shoutouts (7:33 AM)
+
+> "Shoutout time! Big love to everyone tuning in on the commute this morning. Special shout to the early birds in the OwnRadio chat — I see you, and I appreciate you showing up every single day. If you want a shoutout, drop your name in the chat or react to your favorite track. We see every single one. This next one goes out to all of you — let's go!"
+
+---
+
+## HOUR 3 — Morning Momentum (8:00 AM – 9:00 AM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | Midweek motivation |
+| 03 | Song | **Power** |
+| 07 | Song | **Hot Current** |
+| 11 | Song | **Recurrent** |
+| 15 | Weather | Updated weather check |
+| 16 | Song | **Power** |
+| 20 | Song | **Gold** |
+| 24 | Ad Break | Sample Ad #1 (rotate) |
+| 25 | Song | **Hot Current** |
+| 29 | Song | **Power** |
+| 33 | Song | **Recurrent** |
+| 37 | DJ Segment | *"Coming up — your 9 o'clock power hour..."* |
+| 38 | Song | **Gold** |
+| 42 | Song | **Hot Current** |
+| 46 | Song | **Power** |
+| 50 | Ad Break | Sample Ad #2 (rotate) |
+| 51 | Song | **Recurrent** |
+| 55 | Song | **Hot Current** |
+| 58 | DJ Close | |
+
+---
+
+## HOUR 4 — Power Hour (9:00 AM – 10:00 AM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | *"Welcome to the 9 o'clock power hour — no talk, all hits!"* |
+| 02 | Song | **Power** |
+| 06 | Song | **Power** |
+| 10 | Song | **Hot Current** |
+| 14 | Song | **Power** |
+| 18 | Song | **Hot Current** |
+| 22 | Song | **Recurrent** |
+| 26 | Ad Break | Sample Ad #3 |
+| 27 | Song | **Power** |
+| 31 | Song | **Hot Current** |
+| 35 | Song | **Power** |
+| 39 | Song | **Gold** |
+| 43 | Song | **Power** |
+| 47 | Song | **Hot Current** |
+| 51 | Song | **Power** |
+| 55 | Ad Break | Sample Ad #4 |
+| 56 | Song | **Hot Current** |
+| 59 | DJ Close | Quick hit — *"That was the power hour!"* |
+
+---
+
+## HOUR 5 — Late Morning (10:00 AM – 11:00 AM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | Relaxed energy, listener engagement call |
+| 03 | Song | **Hot Current** |
+| 07 | Song | **Recurrent** |
+| 11 | Song | **Gold** |
+| 15 | Joke | **Dad Joke Break** |
+| 16 | Song | **Power** |
+| 20 | Song | **Hot Current** |
+| 24 | Ad Break | Sample Ad #1 |
+| 25 | Song | **Recurrent** |
+| 29 | Song | **Power** |
+| 33 | Song | **Gold** |
+| 37 | DJ Segment | Artist spotlight |
+| 39 | Song | **Hot Current** |
+| 43 | Song | **Recurrent** |
+| 47 | Shoutout | Listener shoutouts from chat |
+| 49 | Song | **Power** |
+| 53 | Ad Break | Sample Ad #2 |
+| 54 | Song | **Hot Current** |
+| 58 | DJ Close | |
+
+### Dad Joke Break (10:15 AM)
+
+> "Okay, okay — it's time for the dad joke of the day. And trust me, this one is terrible in the best way:
+>
+> I knew I shouldn't steal a mixer from work... but it was a whisk I was willing to take.
+>
+> *groan* You're welcome. That's what we do here on OwnRadio — we play the hits AND the bad jokes."
+
+---
+
+## HOUR 6 — Pre-Noon (11:00 AM – 12:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | *"Almost lunchtime..."* |
+| 03–42 | Music block | Alternating Power / Hot Current / Recurrent / Gold (10 songs) |
+| 24 | Ad Break | Sample Ad #3 |
+| 42 | News | **Midday Update** |
+| 45 | Song | **Power** |
+| 49–57 | Music block | 3 songs |
+| 53 | Ad Break | Sample Ad #4 |
+| 58 | DJ Close | Tease noon show |
+
+### Midday News Update (11:42 AM)
+
+> "Here's your OwnRadio Midday Update:
+>
+> Tech news — TechCrunch reporting a wave of new AI startup funding rounds closing this week. The industry shows no signs of slowing down.
+>
+> Music world — NPR Music highlighting emerging artists breaking through on streaming platforms. Some of them you're hearing right here on OwnRadio first.
+>
+> And a quick reminder — you can read, react, and chat live on ownradio.app. Join the conversation!
+>
+> Back to the music."
+
+---
+
+## HOUR 7 — Noon Show (12:00 PM – 1:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | Full station ID read |
+| 01 | DJ Open | **Script below** |
+| 03 | Song | **Power** |
+| 07 | Song | **Hot Current** |
+| 11 | Song | **Gold** |
+| 15 | Weather | Noon weather update |
+| 16 | Song | **Power** |
+| 20 | Song | **Recurrent** |
+| 24 | Ad Break | All 4 ads in rotation |
+| 26 | Song | **Hot Current** |
+| 30 | Joke | **Midday Laugh** |
+| 31 | Song | **Power** |
+| 35 | Song | **Gold** |
+| 39 | Shoutout | **Lunch Crew Shoutouts** |
+| 41 | Song | **Hot Current** |
+| 45 | Song | **Recurrent** |
+| 49 | Song | **Power** |
+| 53 | Ad Break | |
+| 54 | Song | **Hot Current** |
+| 58 | DJ Close | |
+
+### Noon DJ Open (12:00 PM)
+
+> "It's noon on OwnRadio! Wherever you're grabbing lunch — at your desk, in the break room, or out and about — we've got the soundtrack. I'm Alex, and we're rolling through the midday with nothing but hits. The drizzle is letting up a little — still 8 degrees but hey, at least it's not snowing, right? Let's keep this energy going."
+
+### Midday Laugh (12:30 PM)
+
+> "Here's one for the lunch crowd:
+>
+> Oysters hate to give away their pearls... because they're shellfish.
+>
+> *ba dum tss* I'll be here all day. Literally. Until 6 PM. You're stuck with me, OwnRadio!"
+
+### Lunch Crew Shoutouts (12:39 PM)
+
+> "Shoutout to the lunch crew! I know some of you are eating at your desks right now — I see you multitasking. Shoutout to all the first-time listeners discovering OwnRadio today — welcome to the family. And to our regulars in the chat keeping it lively — you ARE OwnRadio. Drop a reaction on the track that's getting you through the day. Let's go!"
+
+---
+
+## HOUR 8 — Early Afternoon (1:00 PM – 2:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | Mellow post-lunch energy |
+| 03–57 | Music-heavy block | 12 songs, lighter DJ talk |
+| 24 | Ad Break | |
+| 37 | DJ Segment | Song intro |
+| 53 | Ad Break | |
+| 58 | DJ Close | |
+
+---
+
+## HOUR 9 — Afternoon (2:00 PM – 3:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | *"Halfway through the afternoon..."* |
+| 03–57 | Music block | 11 songs |
+| 15 | Joke | **Afternoon One-liner** |
+| 24 | Ad Break | |
+| 42 | News | **Afternoon Headlines** |
+| 53 | Ad Break | |
+| 58 | DJ Close | |
+
+### Afternoon One-liner (2:15 PM)
+
+> "Quick one for you: If you're here for the yodeling lesson, please form an orderly orderly orderly queue. ...Get it? Yeah, I'm not sorry."
+
+### Afternoon Headlines (2:42 PM)
+
+> "Your OwnRadio Afternoon Update:
+>
+> Entertainment — E! Online and Page Six buzzing with celebrity news this afternoon. We'll leave the gossip to them — we just play the music.
+>
+> Business — Reuters tracking market moves as the afternoon trading session heats up.
+>
+> And of course, your weather: still that light drizzle hanging around, 8 degrees. Looking like it'll clear up by evening.
+>
+> Stay locked in."
+
+---
+
+## HOUR 10 — Afternoon Drive Warm-Up (3:00 PM – 4:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | Building energy toward drive time |
+| 03–57 | Music block | 12 songs, up-tempo mix |
+| 24 | Ad Break | |
+| 33 | Shoutout | **Afternoon Shoutouts** |
+| 53 | Ad Break | |
+| 58 | DJ Close | *"Drive time is next..."* |
+
+### Afternoon Shoutouts (3:33 PM)
+
+> "Big afternoon shoutout to everyone who's been rocking with OwnRadio all day long. You're the real MVPs. And to the people just tuning in for the drive home — you picked the right station. We've got two more hours of the best music, and I'm taking it home with you. React, chat, and vibe with us at ownradio.app."
+
+---
+
+## HOUR 11 — Afternoon Drive (4:00 PM – 5:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | |
+| 01 | DJ Open | **Drive time energy** |
+| 03 | Song | **Power** |
+| 07 | Song | **Power** |
+| 11 | Song | **Hot Current** |
+| 15 | Weather | Final weather check |
+| 16 | Song | **Power** |
+| 20 | Song | **Recurrent** |
+| 24 | Ad Break | Full rotation |
+| 26 | Song | **Hot Current** |
+| 30 | Song | **Power** |
+| 34 | Song | **Gold** |
+| 38 | DJ Segment | *"Throwback moment..."* |
+| 39 | Song | **Gold** |
+| 43 | Song | **Hot Current** |
+| 47 | Song | **Power** |
+| 51 | Shoutout | Drive-time shoutouts |
+| 53 | Ad Break | |
+| 54 | Song | **Power** |
+| 58 | DJ Close | |
+
+---
+
+## HOUR 12 — Evening Wind-Down (5:00 PM – 6:00 PM)
+
+| Min | Slot | Content |
+|-----|------|---------|
+| 00 | Station ID | Full station ID |
+| 01 | DJ Open | **Script below** |
+| 03 | Song | **Hot Current** |
+| 07 | Song | **Gold** |
+| 11 | Song | **Recurrent** |
+| 15 | Song | **Power** |
+| 19 | Song | **Hot Current** |
+| 23 | Ad Break | |
+| 24 | Song | **Gold** |
+| 28 | Song | **Power** |
+| 32 | News | **Evening Wrap-Up** |
+| 35 | Song | **Hot Current** |
+| 39 | Song | **Recurrent** |
+| 43 | Song | **Power** |
+| 47 | Song | **Gold** |
+| 51 | Ad Break | |
+| 52 | Song | **Hot Current** |
+| 56 | DJ Close | **Sign-Off Script below** |
+
+### Evening DJ Open (5:00 PM)
+
+> "Last hour, OwnRadio! We're taking it home. It's been an incredible Wednesday — great music, great vibes, and the best listeners on the internet. Let's make this last hour count."
+
+### Evening News Wrap-Up (5:32 PM)
+
+> "Your OwnRadio Evening Wrap:
+>
+> Quick recap of the day — tech, entertainment, and world news all kept us busy. Head to your favorite news source for the deep dives tonight.
+>
+> Weather for tomorrow: expecting the drizzle to clear overnight. Should be a nicer Thursday.
+>
+> That's your wrap. Enjoy the evening, OwnRadio fam."
+
+### Sign-Off Script (5:56 PM)
+
+> "And that's a wrap on Wednesday, April 22nd here on OwnRadio! Thank you for spending your day with me — whether you caught the whole show or just dropped in for a few songs, you made this station what it is. I'm Alex, and this has been OwnRadio — your music, your vibe, your station. We'll be right back tomorrow morning at 6 AM. Until then, keep the music playing. Peace, love, and good vibes. OwnRadio out."
+
+---
+
+## Sample Audio Ads
+
+### Ad #1 — Local Coffee Shop (15 sec)
+
+> **[SFX: coffee pouring, gentle morning ambiance]**
+>
+> "Start your morning the right way — Sunrise Cafe, freshly brewed and locally roasted. Mention OwnRadio for 10% off your first order. Sunrise Cafe — your neighborhood coffee spot."
+
+### Ad #2 — OwnRadio App Promo (20 sec)
+
+> **[SFX: notification chime]**
+>
+> "You're listening to OwnRadio — but are you IN OwnRadio? Head to ownradio.app to chat with other listeners, react to your favorite tracks in real time, and see what's playing across all our stations. OwnRadio — it's not just radio, it's community. Join free at ownradio.app."
+
+### Ad #3 — Fitness Studio (15 sec)
+
+> **[SFX: upbeat gym music fade]**
+>
+> "Need a new workout playlist? You already have one — it's called OwnRadio. But if you need the gym to go with it, check out FitZone Studios. First class free. FitZone — where the music hits different."
+
+### Ad #4 — Tech Gadget (15 sec)
+
+> **[SFX: futuristic whoosh]**
+>
+> "The future sounds amazing — especially on the new SoundPod Mini wireless speaker. Crystal clear, pocket-sized, and pairs in seconds. Available now at your favorite electronics retailer. SoundPod Mini — big sound, tiny package."
+
+---
+
+## Content Sources
+
+| Segment | Source |
+|---------|--------|
+| News | info-broker MCP (AP, Reuters, BBC, NPR, Billboard) |
+| Jokes | info-broker MCP (JokeAPI, icanhazdadjoke) |
+| Weather | info-broker MCP (OpenWeatherMap — New York) |
+| Playlist | PlayGen playlist service (rotation categories) |
+| DJ Scripts | PlayGen DJ service (Alex persona) |
+| Ads | Sample/placeholder — replace with real sponsors |
+| Shoutouts | Live from OwnRadio chat + reactions |
+
+---
+
+## Show Clock Summary
+
+| Content Type | Slots/Hour (avg) | Daily Total |
+|---|---|---|
+| Songs | ~10-12 | ~130 |
+| DJ Segments | 2-3 | ~30 |
+| News | 1 (select hours) | 4 |
+| Weather | 1 (select hours) | 4 |
+| Jokes | 1 (select hours) | 4 |
+| Ad Breaks | 2 | 24 |
+| Shoutouts | 1 (select hours) | 5 |
+| Station IDs | 1 | 12 |

--- a/docs/ownradio-listener-platform-plan.md
+++ b/docs/ownradio-listener-platform-plan.md
@@ -1,0 +1,589 @@
+# PlayGen — OwnRadio Listener Platform: Implementation Plan
+
+**Date:** 2026-04-20
+**Scope:** Everything PlayGen needs to build so OwnRadio works end-to-end.
+**Guiding principle:** OwnRadio is a consumer of PlayGen. All work lives in PlayGen.
+
+---
+
+## Context
+
+PlayGen today is a **DJ/admin platform**: playlist scheduling, song library, rotation rules, AI DJ script generation. All routes require auth. OwnRadio is the **listener-facing platform**: browse stations, react, chat — and hear the same AI DJ persona that the station's music director configures.
+
+| | PlayGen (existing) | OwnRadio (new) |
+|---|---|---|
+| Users | DJs, Music Directors, Admins | Listeners (public) |
+| Auth | Company-scoped JWT (RBAC) | Listener JWT (email/Google) |
+| Data | Song library, playlists, DJ scripts | Now-playing, reactions, chat |
+| Real-time | None | Socket.io (chat, reactions, presence, DJ commentary) |
+| DJ | AI persona in `dj_profiles` | **Same `dj_profiles` record** |
+
+**There is no human/AI distinction.** The DJ shown on OwnRadio's station card is the PlayGen `dj_profiles` record — the same persona the music director configures. `dj_daypart_assignments` determines which persona is active at which hour.
+
+---
+
+## What OwnRadio Needs
+
+### REST (public unless noted)
+| Endpoint | Notes |
+|---|---|
+| `GET /public/stations` | Live stations with active DJ persona |
+| `GET /public/stations/:slug` | Station detail + active DJ |
+| `GET /public/stations/:slug/top-songs` | Top 10 by reaction count |
+| `GET /public/stations/:slug/top-listeners` | Top 10 by activity |
+| `POST /listener/auth/register` | Email registration |
+| `POST /listener/auth/login` | Returns access + refresh tokens |
+| `POST /listener/auth/refresh` | Rotate refresh token |
+| `POST /listener/auth/logout` | Revoke refresh token |
+| `GET /auth/google/listener` | Google OAuth listener flow |
+| `GET /auth/google/listener/callback` | Google OAuth callback |
+| `GET /listener/me` | Profile (auth required) |
+
+### WebSocket (Socket.io)
+| Direction | Event | Payload | Auth |
+|---|---|---|---|
+| C→S | `join_station` | `{ slug }` | No |
+| C→S | `leave_station` | — | No |
+| C→S | `reaction` | `{ songId, type }` | No |
+| C→S | `chat_message` | `{ content }` | Yes |
+| S→C | `now_playing` | `{ id, title, artist, albumCoverUrl }` | — |
+| S→C | `dj_commentary` | `{ scriptText, audioUrl\|null, songId }` | — |
+| S→C | `reaction_update` | `{ songId, counts }` | — |
+| S→C | `new_message` | `{ displayName, content, createdAt }` | — |
+| S→C | `listener_count` | `{ slug, count }` | — |
+| S→C | `station_status` | `{ isLive }` | — |
+
+---
+
+## What NOT to Build
+
+- DJ dashboard UI changes (existing PlayGen frontend unaffected)
+- Playlist generation, rotation rules, export adapters (untouched)
+- Streaming infrastructure (audio flows Icecast → browser directly)
+- A separate "human DJ" entity — `dj_profiles` is the DJ, full stop
+
+---
+
+## Architecture: Two Additions
+
+**1. `listener-service`** (new, port 3007) — listener auth, Socket.io, metadata poller, reactions, chat.
+
+**2. `dj-service` extension** — one new internal-only endpoint for live on-demand commentary. All LLM/TTS machinery already exists; this adds a lightweight path that needs no playlist.
+
+**`station-service`** gets one new unauthenticated route group (`/public/*`).
+
+```
+Nginx Gateway
+  /api/v1/public/*              → station-service  (new public routes, no auth)
+  /api/v1/listener/*            → listener-service (new)
+  /api/v1/auth/google/listener* → listener-service
+  /socket.io/*                  → listener-service (WebSocket upgrade)
+
+Internal Docker network only (not gateway-exposed):
+  listener-service → dj-service   POST /internal/dj/commentary
+```
+
+---
+
+## Database Changes
+
+Next migration number: **057**
+
+### Migration 057 — Add listener-facing fields to stations
+
+```sql
+ALTER TABLE stations
+  ADD COLUMN slug           VARCHAR(100) UNIQUE,
+  ADD COLUMN stream_url     VARCHAR(500),
+  ADD COLUMN metadata_url   VARCHAR(500),
+  ADD COLUMN is_live        BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN artwork_url    VARCHAR(500),
+  ADD COLUMN genre          VARCHAR(50),
+  ADD COLUMN dj_profile_id  UUID REFERENCES dj_profiles(id) ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX idx_stations_slug ON stations(slug) WHERE slug IS NOT NULL;
+```
+
+> `dj_profile_id` is the default/fallback DJ for this station. At query time resolve active DJ as:
+> daypart assignment for current hour → fallback to `stations.dj_profile_id` → null.
+>
+> **Why not dj_name/dj_bio/dj_avatar_url?** `dj_profiles` already has name, personality, voice_style.
+> Duplicating them creates two sources of truth.
+
+### Migration 058 — Create listeners
+
+```sql
+CREATE TABLE listeners (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  username      VARCHAR(50)  UNIQUE NOT NULL,
+  email         VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255),
+  google_id     VARCHAR(255) UNIQUE,
+  avatar_url    VARCHAR(500),
+  is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_listeners_email ON listeners(email);
+```
+
+### Migration 059 — Create listener_refresh_tokens
+
+```sql
+CREATE TABLE listener_refresh_tokens (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  listener_id UUID NOT NULL REFERENCES listeners(id) ON DELETE CASCADE,
+  token_hash  VARCHAR(255) NOT NULL UNIQUE,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_listener_refresh_tokens_listener ON listener_refresh_tokens(listener_id);
+```
+
+### Migration 060 — Create listener_songs
+
+Songs detected from Icecast metadata. Separate from PlayGen `play_history` (scheduled playlist entries).
+
+```sql
+CREATE TABLE listener_songs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  station_id      UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+  title           VARCHAR(200) NOT NULL,
+  artist          VARCHAR(200) NOT NULL,
+  album_cover_url VARCHAR(500),
+  played_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_listener_songs_station   ON listener_songs(station_id);
+CREATE INDEX idx_listener_songs_played_at ON listener_songs(station_id, played_at DESC);
+```
+
+### Migration 061 — Create listener_reactions
+
+```sql
+CREATE TABLE listener_reactions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  song_id     UUID NOT NULL REFERENCES listener_songs(id) ON DELETE CASCADE,
+  station_id  UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+  listener_id UUID REFERENCES listeners(id) ON DELETE SET NULL,
+  type        VARCHAR(20) NOT NULL CHECK (type IN ('heart','rock','party','broken_heart')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (song_id, listener_id, type)
+);
+CREATE INDEX idx_listener_reactions_song ON listener_reactions(station_id, song_id);
+```
+
+### Migration 062 — Create listener_chat_messages
+
+```sql
+CREATE TABLE listener_chat_messages (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  station_id   UUID NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+  listener_id  UUID REFERENCES listeners(id) ON DELETE SET NULL,
+  display_name VARCHAR(50)  NOT NULL,
+  content      VARCHAR(280) NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_listener_chat_station ON listener_chat_messages(station_id, created_at DESC);
+```
+
+---
+
+## Active DJ Resolution (shared helper)
+
+Both the public API and the metadata poller need: "which DJ profile is on right now?"
+
+```sql
+SELECT dp.id, dp.name, dp.personality, dp.voice_style,
+       dp.tts_provider, dp.tts_voice_id, dp.llm_model, dp.llm_temperature
+FROM stations s
+LEFT JOIN LATERAL (
+  SELECT dpa.dj_profile_id
+  FROM dj_daypart_assignments dpa
+  WHERE dpa.station_id = s.id
+    AND dpa.start_hour <= EXTRACT(HOUR FROM NOW() AT TIME ZONE s.timezone)
+    AND dpa.end_hour   >  EXTRACT(HOUR FROM NOW() AT TIME ZONE s.timezone)
+  LIMIT 1
+) active_daypart ON TRUE
+LEFT JOIN dj_profiles dp
+  ON dp.id = COALESCE(active_daypart.dj_profile_id, s.dj_profile_id)
+ AND dp.is_active = TRUE
+WHERE s.id = $1
+```
+
+---
+
+## Implementation Plan
+
+---
+
+### Task 1 — Migrations 057–062
+
+**Files:** `shared/db/src/migrations/057_add_station_listener_fields.sql` through `062_create_listener_chat_messages.sql`
+
+- [ ] Write all 6 migration files
+- [ ] `docker compose up db -d && pnpm --filter @playgen/db migrate`
+- [ ] Verify: `psql $DATABASE_URL -c "\d stations"` shows new columns
+- [ ] Check `tasks/agent-collab.md` — no migration conflicts at 057–062
+- [ ] Commit: `feat(db): add listener-platform migrations 057-062`
+
+---
+
+### Task 2 — station-service: public station API
+
+**Files:**
+- `services/station/src/routes/publicStations.ts` (new)
+- `services/station/src/services/publicStationService.ts` (new)
+- `services/station/src/app.ts` (register before authenticate hook)
+
+No `authenticate` hook on any of these routes.
+
+**GET /public/stations** — stations with slug, ordered `is_live DESC, name ASC`. Response per station:
+```json
+{
+  "id": "uuid", "name": "Rock Haven", "slug": "rock-haven",
+  "genre": "Rock", "artworkUrl": "...", "streamUrl": "...", "isLive": true,
+  "listenerCount": 12,
+  "dj": { "id": "uuid", "name": "Alex", "voiceStyle": "energetic" }
+}
+```
+
+**GET /public/stations/:slug** — same + `dj.personality` (shown as bio) + last 5 `listener_songs`.
+
+**GET /public/stations/:slug/top-songs**
+```sql
+SELECT ls.id, ls.title, ls.artist, ls.album_cover_url, ls.played_at,
+       COUNT(r.id) AS reaction_count
+FROM listener_songs ls
+JOIN listener_reactions r ON r.song_id = ls.id
+WHERE ls.station_id = $1 AND ls.played_at > NOW() - INTERVAL '24h'
+GROUP BY ls.id
+ORDER BY reaction_count DESC LIMIT 10
+```
+
+**GET /public/stations/:slug/top-listeners**
+```sql
+SELECT l.id, l.username, l.avatar_url,
+       COUNT(DISTINCT r.id) + COUNT(DISTINCT m.id) AS total_score
+FROM listeners l
+LEFT JOIN listener_reactions r     ON r.listener_id = l.id AND r.station_id = $1
+LEFT JOIN listener_chat_messages m ON m.listener_id = l.id AND m.station_id = $1
+GROUP BY l.id
+HAVING COUNT(DISTINCT r.id) + COUNT(DISTINCT m.id) > 0
+ORDER BY total_score DESC LIMIT 10
+```
+
+- [ ] Implement service + routes
+- [ ] Register in `app.ts` before the global `authenticate` hook
+- [ ] Tests: 6 (list, slug lookup, unknown 404, top-songs, top-listeners, null dj when none configured)
+- [ ] `pnpm --filter @playgen/station-service test` — all pass
+- [ ] Commit: `feat(station): add public station API for OwnRadio`
+
+---
+
+### Task 3 — Scaffold listener-service
+
+**Files:** `services/listener/package.json`, `tsconfig.json`, `src/app.ts`, `src/index.ts`, `src/db.ts`, `vitest.config.ts`
+
+Uses `pg` directly (consistent with monorepo). `buildApp()` factory for testability; Socket.io attached in `index.ts` after `app.listen()`.
+
+Key deps: `fastify ^5.8.4`, `@fastify/cors`, `@fastify/rate-limit`, `socket.io ^4`, `bcryptjs ^2`, `jsonwebtoken ^9`, `@playgen/middleware workspace:*`, `@playgen/types workspace:*`, `pg ^8`
+
+Add to `docker-compose.yml`:
+```yaml
+listener:
+  build: ./services/listener
+  ports: ["3007:3007"]
+  depends_on: [postgres]
+  environment:
+    DATABASE_URL: ${DATABASE_URL}
+    JWT_LISTENER_SECRET: ${JWT_LISTENER_SECRET}
+    CORS_ORIGIN: ${CORS_ORIGIN}
+    DJ_SERVICE_INTERNAL_URL: ${DJ_SERVICE_INTERNAL_URL}
+```
+
+`DJ_SERVICE_INTERNAL_URL` is defined in `.env.example` and resolves to the dj-service on the Docker internal network. Never hardcoded.
+
+- [ ] Create all scaffold files
+- [ ] `pnpm --filter @playgen/listener-service typecheck` — passes
+- [ ] Add service to `docker-compose.yml` using env var for internal URL
+- [ ] Add `JWT_LISTENER_SECRET` and `DJ_SERVICE_INTERNAL_URL` to `.env.example`
+- [ ] Commit: `feat(listener): scaffold listener-service`
+
+---
+
+### Task 4 — Listener auth
+
+**Files:** `src/routes/auth.ts`, `src/services/authService.ts`, `src/lib/jwt.ts`, `src/tests/routes/auth.test.ts`
+
+Listener JWT is separate from PlayGen company-user JWT. Different env var `JWT_LISTENER_SECRET`, different payload:
+```ts
+{ listenerId: string; username: string }
+// access_token: 15 min  |  refresh_token: 7 days (rotated, SHA-256 hash stored)
+```
+
+Routes:
+```
+POST /listener/auth/register   { username, email, password } → 201 { user, access_token, refresh_token }
+POST /listener/auth/login      { email, password }           → 200 { user, access_token, refresh_token }
+POST /listener/auth/refresh    { refresh_token }             → 200 { access_token, refresh_token }
+POST /listener/auth/logout     { refresh_token }             → 204
+GET  /listener/me              Bearer required               → 200 { id, username, email, avatar_url }
+```
+
+Rules: password ≥ 8 chars, bcrypt cost 12, 409 on duplicate email/username. `password_hash` never in responses. Refresh token: SHA-256 hash stored; on use, verify → delete old → insert new.
+
+Google OAuth placeholder returns 501, implemented in Task 8.
+
+- [ ] Write 7 failing tests
+- [ ] Run → FAIL
+- [ ] Implement
+- [ ] Run → PASS
+- [ ] Commit: `feat(listener): add listener auth with JWT`
+
+---
+
+### Task 5 — dj-service: live commentary endpoint
+
+**Files:**
+- `services/dj/src/routes/commentary.ts` (new)
+- `services/dj/src/services/commentaryService.ts` (new)
+- `services/dj/src/app.ts` (register — internal only, not gateway-exposed)
+
+New lightweight path through existing machinery. No BullMQ queue, no playlist, no review workflow — generate one `song_intro` synchronously.
+
+**Endpoint:**
+```
+POST /internal/dj/commentary
+Body:     { stationId, djProfileId, song: { title, artist } }
+Response: 200 { scriptText: string, audioUrl: string | null }
+          204 (no DJ configured or generation skipped)
+```
+
+**`commentaryService.ts`:**
+1. Load `dj_profiles` row for `djProfileId`
+2. Load station row (name, timezone, identity fields)
+3. Call `llmComplete` with `buildSystemPrompt(profile)` + `buildUserPrompt({ segment_type: 'song_intro', song, station_name, ... })`
+4. If `tts_provider` set and station has TTS API key: call `generateSegmentTts`, return `audioUrl`; else `audioUrl: null`
+5. Do NOT write to `dj_scripts` or `dj_segments` — live commentary is ephemeral
+
+**No auth on this route** — never exposed through Nginx. Only reachable on Docker internal network by `listener-service` via `DJ_SERVICE_INTERNAL_URL`.
+
+- [ ] Implement `commentaryService.ts` — reuse `llmComplete`, `buildSystemPrompt`, `buildUserPrompt`, `generateSegmentTts`
+- [ ] Implement `commentary.ts` route
+- [ ] Register in `dj/src/app.ts`
+- [ ] Unit tests: mock `llmComplete` + `generateSegmentTts`, verify correct prompt context, verify null audioUrl when no TTS key configured
+- [ ] `pnpm --filter @playgen/dj-service test` — all pass
+- [ ] Commit: `feat(dj): add internal live commentary endpoint for OwnRadio`
+
+---
+
+### Task 6 — Socket.io + metadata poller
+
+**Files:** `services/listener/src/ws/index.ts`, `chat.ts`, `reactions.ts`, `metadata.ts`, `src/index.ts`, `src/tests/ws/chat.test.ts`
+
+**`ws/index.ts`:**
+- Verify `handshake.auth.token` against `JWT_LISTENER_SECRET`; set `socket.data.listenerId` + `socket.data.username` if valid; else anonymous
+- `join_station { slug }` → join room, save slug on socket, broadcast `listener_count`
+- `leave_station` → leave room (slug from socket data), broadcast updated count
+- `disconnect` → broadcast updated count
+
+**`ws/reactions.ts`:**
+- Toggle: upsert/delete `listener_reactions` on `(song_id, listener_id, type)` unique constraint
+- Anonymous: skip DB write, broadcast optimistically
+- Debounce 500ms: emit `reaction_update { songId, counts }` per station+song
+
+**`ws/chat.ts`:**
+- Require `socket.data.listenerId` — else emit `error { code: 'AUTH_REQUIRED' }`
+- Validate 1–280 chars, INSERT, broadcast `new_message`
+
+**`ws/metadata.ts` — with DJ commentary:**
+
+```ts
+async function pollStation(io, stationId, slug, metadataUrl, timezone) {
+  const metadata = await fetchIcecastMetadata(metadataUrl);
+  if (!metadata) return;
+
+  const songKey = `${metadata.artist} - ${metadata.title}`;
+  if (lastSongByStation.get(stationId) === songKey) return;
+  lastSongByStation.set(stationId, songKey);
+
+  const song = await insertListenerSong(stationId, metadata);
+  io.to(`station:${slug}`).emit('now_playing', song);
+
+  // Resolve active DJ and request live commentary (fire-and-forget — never crash the poller)
+  const dj = await resolveActiveDj(stationId, timezone);
+  if (dj) {
+    fetchLiveCommentary(stationId, dj.id, metadata)
+      .then(commentary => {
+        if (commentary) {
+          io.to(`station:${slug}`).emit('dj_commentary', {
+            scriptText: commentary.scriptText,
+            audioUrl:   commentary.audioUrl,
+            songId:     song.id,
+          });
+        }
+      })
+      .catch(err => console.error('dj commentary failed, skipping:', err));
+  }
+}
+```
+
+`fetchLiveCommentary` POSTs to `process.env.DJ_SERVICE_INTERNAL_URL + '/internal/dj/commentary'`.
+
+`startMetadataPollers(io)`: load `WHERE is_live = true AND metadata_url IS NOT NULL`, setInterval 5s per station, setInterval 30s for discovery.
+
+`stopAllPollers()`: clear all intervals + Maps.
+
+**`index.ts`:**
+```ts
+await app.listen({ port: 3007, host: '0.0.0.0' });
+const io = new Server(app.server, { cors: { origin: process.env.CORS_ORIGIN } });
+setupSocketHandlers(io);
+startMetadataPollers(io);
+const shutdown = () => { stopAllPollers(); app.close().then(() => process.exit(0)); };
+process.on('SIGTERM', shutdown);
+process.on('SIGINT',  shutdown);
+```
+
+- [ ] Write chat test: real Socket.io server port 0, mock pg pool, join station, emit chat_message, verify new_message
+- [ ] Run → FAIL
+- [ ] Implement all ws/* + index.ts
+- [ ] Run → PASS
+- [ ] Commit: `feat(listener): add socket.io with chat, reactions, metadata poller, dj commentary`
+
+---
+
+### Task 7 — Nginx gateway routing
+
+**File:** `gateway/nginx.conf`
+
+Add `listener` upstream and location blocks. The `/api/v1/public/` block must come **before** any catch-all auth location.
+
+```nginx
+upstream listener {
+  server listener:3007;
+}
+
+# Public station API — no auth
+location /api/v1/public/ {
+  proxy_pass       http://station/;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header Host $host;
+}
+
+# Listener REST
+location /api/v1/listener/ {
+  proxy_pass       http://listener/listener/;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header Host $host;
+}
+
+# Google OAuth for listeners
+location /api/v1/auth/google/listener {
+  proxy_pass       http://listener;
+  proxy_set_header Host $host;
+}
+
+# Socket.io WebSocket upgrade
+location /socket.io/ {
+  proxy_pass           http://listener;
+  proxy_http_version   1.1;
+  proxy_set_header     Upgrade $http_upgrade;
+  proxy_set_header     Connection "upgrade";
+  proxy_set_header     Host $host;
+  proxy_read_timeout   86400s;
+}
+```
+
+Note: `/internal/dj/` is intentionally NOT routed through Nginx.
+
+- [ ] Add upstream + locations
+- [ ] `docker compose up --build gateway`
+- [ ] `curl http://localhost/api/v1/public/stations` → JSON array
+- [ ] `curl http://localhost/api/v1/listener/me` → 401
+- [ ] Commit: `feat(gateway): add routing for public API, listener service, socket.io`
+
+---
+
+### Task 8 — Google OAuth for listeners
+
+**Files:** `services/listener/src/routes/oauth.ts`, `src/services/oauthService.ts`
+
+```
+GET /auth/google/listener          → redirect to Google
+GET /auth/google/listener/callback → upsert listener, redirect to OwnRadio with tokens
+```
+
+**Upsert logic** (Google profile: `email`, `sub`, `name`, `picture`):
+1. `listeners.google_id = sub` → existing linked account, issue tokens
+2. `listeners.email = email` → link `google_id` to existing account, issue tokens
+3. Neither → create listener (`username` = slugified name + 4-char suffix), issue tokens
+
+Tokens returned as query params on redirect to `OWNRADIO_REDIRECT_URL`. Frontend stores and clears URL.
+
+Required env vars: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_LISTENER_REDIRECT_URI`, `OWNRADIO_REDIRECT_URL` — all in `.env.example`.
+
+- [ ] Implement `oauthService.ts` (3 scenarios, unit-tested with mocked pool)
+- [ ] Implement `oauth.ts` route
+- [ ] Commit: `feat(listener): add Google OAuth for listener login`
+
+---
+
+### Task 9 — Seed data
+
+**File:** `shared/db/src/seeds/ownradio.ts`
+
+4 demo stations (Rock Haven, Beat Lounge, Chill Waves, Pinoy Hits), each with `slug`, `stream_url`, `metadata_url`, `is_live: true`, `genre`, `artwork_url`, `dj_profile_id` linked to the company's default `dj_profiles` row.
+
+1 demo listener — email/password read from `DEMO_LISTENER_EMAIL` + `DEMO_LISTENER_PASSWORD` env vars.
+
+Add to `shared/db/package.json`: `"seed:ownradio": "tsx src/seeds/ownradio.ts"`
+
+- [ ] Write seed
+- [ ] `pnpm --filter @playgen/db seed:ownradio`
+- [ ] `GET /api/v1/public/stations` → 4 stations with `dj` object
+- [ ] Commit: `feat(db): add ownradio demo station seed`
+
+---
+
+### Task 10 — Integration smoke test
+
+- [ ] `docker compose up --build -d`
+- [ ] `pnpm --filter @playgen/db migrate && pnpm --filter @playgen/db seed:ownradio`
+- [ ] `GET /api/v1/public/stations` → 4 stations, `dj.name` present
+- [ ] `POST /api/v1/listener/auth/login` → `{ access_token, refresh_token, user }`
+- [ ] WS: connect, emit `join_station { slug: 'rock-haven' }` → receive `listener_count`
+- [ ] WS: emit `chat_message { content: 'hello' }` with valid token → receive `new_message`
+- [ ] WS: verify `dj_commentary` fires within 10s of a song change (mock metadata endpoint or trigger `pollStation` directly)
+- [ ] `GET /api/v1/public/stations/rock-haven/top-songs` → empty array (not error)
+- [ ] Document gaps under **Post-smoke-test fixes** heading below
+- [ ] Commit: `chore(listener): integration smoke test sign-off`
+
+---
+
+## OwnRadio Frontend Changes (after PlayGen tasks complete)
+
+- [ ] Delete `apps/api/` from ownradio (Fastify, Prisma, seeds, tests)
+- [ ] Remove `api` service from ownradio `docker-compose.yml`
+- [ ] `apps/web/.env.local`: point both URLs at PlayGen gateway
+- [ ] `apps/web/src/lib/api.ts`: token shape → `access_token` / `refresh_token` (15 min / 7 day rotation)
+- [ ] `apps/web/src/hooks/useAuth.ts`: add refresh rotation (retry on 401)
+- [ ] `apps/web/src/components/station/DJSection.tsx`: handle `dj_commentary` event — show `scriptText`; if `audioUrl` present, auto-play before song
+- [ ] Remove `packages/shared/` or keep as thin re-export of PlayGen types
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (migrations)        ─────────────────────────────┐
+Task 2 (public API)        ── after 1                   │
+Task 3 (scaffold)          ── independent               ├── Task 9 (seed) ── Task 10 (smoke)
+Task 4 (listener auth)     ── after 3                   │
+Task 5 (dj live endpoint)  ── independent               │
+Task 6 (socket.io)         ── after 4 + 5               │
+Task 7 (nginx)             ── after 3                   │
+Task 8 (Google OAuth)      ── after 4                   ┘
+```
+
+Parallelizable immediately: Tasks 1, 3, 5, 7.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
 
   frontend:
     dependencies:
@@ -37,8 +37,8 @@ importers:
         specifier: ^4.0.0
         version: 4.2.2
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -47,13 +47,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.9)
       next:
         specifier: ^16.2.3
         version: 16.2.3(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       postcss:
-        specifier: ^8.4.49
-        version: 8.5.8
+        specifier: ^8.5.9
+        version: 8.5.9
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -72,7 +72,7 @@ importers:
         version: 1.59.1
       vitest:
         specifier: '*'
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/analytics:
     dependencies:
@@ -99,8 +99,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -108,8 +108,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/auth:
     dependencies:
@@ -154,8 +154,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -169,8 +169,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/dj:
     dependencies:
@@ -218,8 +218,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -230,14 +230,14 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/library:
     dependencies:
       '@fastify/multipart':
-        specifier: ^9.0.0
-        version: 9.4.0
+        specifier: ^10.0.0
+        version: 10.0.0
       '@fastify/sensible':
         specifier: ^6.0.0
         version: 6.0.4
@@ -258,8 +258,8 @@ importers:
         version: 8.20.0
     devDependencies:
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -273,8 +273,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/playlist:
     dependencies:
@@ -304,8 +304,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -313,8 +313,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/scheduler:
     dependencies:
@@ -350,8 +350,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
@@ -362,8 +362,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   services/station:
     dependencies:
@@ -399,8 +399,8 @@ importers:
         specifier: ^9.0.6
         version: 9.0.10
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/pg':
         specifier: ^8.11.0
         version: 8.20.0
@@ -414,8 +414,8 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   shared/billing:
     dependencies:
@@ -437,7 +437,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@25.5.2)(vite@8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.2(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
 
   shared/db:
     dependencies:
@@ -1085,6 +1085,9 @@ packages:
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/multipart@10.0.0':
+    resolution: {integrity: sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==}
 
   '@fastify/multipart@9.4.0':
     resolution: {integrity: sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==}
@@ -1871,6 +1874,9 @@ packages:
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
@@ -1976,8 +1982,22 @@ packages:
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
   '@vitest/mocker@4.1.2':
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1990,17 +2010,32 @@ packages:
   '@vitest/pretty-format@4.1.2':
     resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
 
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
   '@vitest/spy@4.1.2':
     resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
@@ -3128,10 +3163,6 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3497,6 +3528,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   unzipper@0.10.14:
     resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
 
@@ -3598,6 +3632,47 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4361,6 +4436,14 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  '@fastify/multipart@10.0.0':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/error': 4.2.0
+      fastify-plugin: 5.1.0
+      secure-json-parse: 4.1.0
+
   '@fastify/multipart@9.4.0':
     dependencies:
       '@fastify/busboy': 3.2.0
@@ -5091,7 +5174,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.9
       tailwindcss: 4.2.2
 
   '@tybys/wasm-util@0.10.1':
@@ -5101,7 +5184,7 @@ snapshots:
 
   '@types/bcrypt@6.0.0':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@types/bcryptjs@2.4.6': {}
 
@@ -5125,7 +5208,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
 
   '@types/methods@1.1.4': {}
 
@@ -5143,9 +5226,13 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -5161,7 +5248,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 25.5.2
+      '@types/node': 25.6.0
       form-data: 4.0.5
 
   '@types/supertest@7.2.0':
@@ -5298,6 +5385,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@4.1.2(vite@8.0.8(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.2
@@ -5314,13 +5410,38 @@ snapshots:
     optionalDependencies:
       vite: 8.0.8(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
 
+  '@vitest/mocker@4.1.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
+
   '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
 
   '@vitest/runner@4.1.2':
     dependencies:
       '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.2':
@@ -5330,11 +5451,26 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.1.2': {}
+
+  '@vitest/spy@4.1.5': {}
 
   '@vitest/utils@4.1.2':
     dependencies:
       '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -5418,13 +5554,13 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.9):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001784
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
   avvio@9.2.0:
@@ -6511,12 +6647,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
@@ -6887,6 +7017,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.19.2: {}
+
   unzipper@0.10.14:
     dependencies:
       big-integer: 1.6.52
@@ -6948,6 +7080,20 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
 
+  vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+
   vitest@4.1.2(@types/node@20.19.37)(vite@8.0.8(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.2
@@ -6999,6 +7145,60 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.2(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
 

--- a/services/dj/src/index.ts
+++ b/services/dj/src/index.ts
@@ -15,6 +15,8 @@ import { socialAuthRoutes } from './routes/socialAuth.js';
 import { adlibClipRoutes } from './routes/adlibClips.js';
 import { usageRoutes } from './routes/usage.js';
 import { segmentRoutes } from './routes/segments.js';
+import { manifestRoutes } from './routes/manifests.js';
+import { streamRoutes } from './playout/streamRoutes.js';
 import { closeQueue } from './queues/djQueue.js';
 import { scheduleAudioCleanup, closeCleanupQueue } from './queues/audioCleanupQueue.js';
 
@@ -66,6 +68,8 @@ app.register(socialAuthRoutes,     { prefix: '/api/v1' });
 app.register(adlibClipRoutes,     { prefix: '/api/v1' });
 app.register(usageRoutes,         { prefix: '/api/v1' });
 app.register(segmentRoutes,       { prefix: '/api/v1' });
+app.register(manifestRoutes);  // Internal routes, no prefix — not gateway-exposed
+app.register(streamRoutes);    // HLS streaming + playout control
 
 // ── Error handler ─────────────────────────────────────────────────────────────
 

--- a/services/dj/src/playout/hlsGenerator.ts
+++ b/services/dj/src/playout/hlsGenerator.ts
@@ -1,0 +1,141 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import type { ProgramManifest } from '../services/manifestService.js';
+import { getStorageAdapter } from '../lib/storage/index.js';
+
+const execFileAsync = promisify(execFile);
+
+const HLS_OUTPUT_DIR = process.env.HLS_OUTPUT_PATH || path.join(process.cwd(), 'data', 'hls');
+const TARGET_DURATION = 10; // seconds per HLS segment
+
+export interface HlsState {
+  stationId: string;
+  playlistPath: string;   // path to the live .m3u8 file
+  segmentDir: string;     // directory containing .ts segments
+  totalSegments: number;
+}
+
+/**
+ * Generate HLS segments from a program manifest.
+ *
+ * For each audio file in the manifest, transcodes to MPEG-TS segments
+ * and builds a live-style M3U8 playlist.
+ */
+export async function generateHls(stationId: string, manifest: ProgramManifest): Promise<HlsState> {
+  const stationDir = path.join(HLS_OUTPUT_DIR, stationId);
+  fs.mkdirSync(stationDir, { recursive: true });
+
+  const playlistPath = path.join(stationDir, 'playlist.m3u8');
+  const segmentDir = stationDir;
+
+  // Build a concat list for ffmpeg
+  const concatListPath = path.join(stationDir, 'concat.txt');
+  const storage = getStorageAdapter();
+  const lines: string[] = [];
+
+  for (const seg of manifest.segments) {
+    if (!seg.audio_url) continue;
+    // Resolve audio URL to a local file path
+    const localPath = await resolveAudioPath(seg.audio_url, storage);
+    if (localPath && fs.existsSync(localPath)) {
+      lines.push(`file '${localPath.replace(/'/g, "'\\''")}'`);
+    }
+  }
+
+  if (lines.length === 0) {
+    throw new Error('No audio files found in manifest');
+  }
+
+  await fs.promises.writeFile(concatListPath, lines.join('\n'));
+
+  // Transcode all audio into HLS
+  const segmentPattern = path.join(segmentDir, 'segment-%05d.ts');
+  await execFileAsync('ffmpeg', [
+    '-y',
+    '-f', 'concat',
+    '-safe', '0',
+    '-i', concatListPath,
+    '-c:a', 'aac',
+    '-b:a', '128k',
+    '-ac', '2',
+    '-ar', '44100',
+    '-f', 'hls',
+    '-hls_time', String(TARGET_DURATION),
+    '-hls_list_size', '0',       // Keep all segments in playlist
+    '-hls_segment_filename', segmentPattern,
+    '-hls_playlist_type', 'vod', // Full playlist (not live windowed)
+    playlistPath,
+  ], { timeout: 600_000 }); // 10 min timeout for long programs
+
+  // Count generated segments
+  const files = await fs.promises.readdir(segmentDir);
+  const totalSegments = files.filter(f => f.endsWith('.ts')).length;
+
+  // Clean up concat list
+  fs.promises.unlink(concatListPath).catch(() => {});
+
+  return { stationId, playlistPath, segmentDir, totalSegments };
+}
+
+/**
+ * Generate a live-style sliding window M3U8 for a specific position.
+ * Returns a playlist with only the current and next few segments.
+ */
+export function generateLivePlaylist(
+  stationId: string,
+  currentSegmentTsIndex: number,
+  totalSegments: number,
+  windowSize = 3,
+): string {
+  const startIdx = Math.max(0, currentSegmentTsIndex);
+  const endIdx = Math.min(totalSegments, startIdx + windowSize);
+
+  const lines = [
+    '#EXTM3U',
+    `#EXT-X-VERSION:3`,
+    `#EXT-X-TARGETDURATION:${TARGET_DURATION}`,
+    `#EXT-X-MEDIA-SEQUENCE:${startIdx}`,
+  ];
+
+  for (let i = startIdx; i < endIdx; i++) {
+    lines.push(`#EXTINF:${TARGET_DURATION},`);
+    lines.push(`segment-${String(i).padStart(5, '0')}.ts`);
+  }
+
+  if (endIdx >= totalSegments) {
+    lines.push('#EXT-X-ENDLIST');
+  }
+
+  return lines.join('\n');
+}
+
+/** Resolve an audio_url to a local filesystem path. */
+async function resolveAudioPath(
+  audioUrl: string,
+  storage: ReturnType<typeof getStorageAdapter>,
+): Promise<string | null> {
+  // If it's already an absolute path
+  if (path.isAbsolute(audioUrl) && fs.existsSync(audioUrl)) {
+    return audioUrl;
+  }
+
+  // Try as a storage-relative path
+  try {
+    const buffer = await storage.read(audioUrl);
+    // Write to a temp location for ffmpeg access
+    const tmpPath = path.join(HLS_OUTPUT_DIR, '.cache', audioUrl.replace(/[/\\]/g, '_'));
+    fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
+    await fs.promises.writeFile(tmpPath, buffer);
+    return tmpPath;
+  } catch {
+    return null;
+  }
+}
+
+/** Clean up HLS files for a station. */
+export async function cleanupHls(stationId: string): Promise<void> {
+  const stationDir = path.join(HLS_OUTPUT_DIR, stationId);
+  await fs.promises.rm(stationDir, { recursive: true, force: true });
+}

--- a/services/dj/src/playout/playoutScheduler.ts
+++ b/services/dj/src/playout/playoutScheduler.ts
@@ -1,0 +1,165 @@
+import { getPool } from '../db.js';
+import { getStorageAdapter } from '../lib/storage/index.js';
+import type { ProgramManifest, ProgramManifestSegment } from '../services/manifestService.js';
+
+export interface PlayoutState {
+  stationId: string;
+  manifest: ProgramManifest;
+  startedAt: number;  // Unix timestamp (ms) when playout began
+  currentSegmentIndex: number;
+  isPlaying: boolean;
+}
+
+export interface NowPlaying {
+  segment: ProgramManifestSegment;
+  elapsed_sec: number;
+  remaining_sec: number;
+  next_segment?: ProgramManifestSegment;
+}
+
+/** In-memory map of active station playouts. */
+const activePlayouts = new Map<string, PlayoutState>();
+
+/** Event listeners for segment transitions. */
+type SegmentChangeListener = (stationId: string, segment: ProgramManifestSegment, next?: ProgramManifestSegment) => void;
+const listeners: SegmentChangeListener[] = [];
+
+export function onSegmentChange(fn: SegmentChangeListener) {
+  listeners.push(fn);
+}
+
+function notifyListeners(stationId: string, segment: ProgramManifestSegment, next?: ProgramManifestSegment) {
+  for (const fn of listeners) {
+    try { fn(stationId, segment, next); } catch { /* ignore listener errors */ }
+  }
+}
+
+/**
+ * Start playout for a station using its latest published episode manifest.
+ */
+export async function startPlayout(stationId: string): Promise<PlayoutState | null> {
+  const pool = getPool();
+
+  // Find the latest published episode with a manifest for this station
+  const { rows: [episode] } = await pool.query(
+    `SELECT pe.id, pe.air_date, m.manifest_url
+     FROM program_episodes pe
+     JOIN programs p ON p.id = pe.program_id
+     JOIN dj_show_manifests m ON m.id = pe.manifest_id
+     WHERE p.station_id = $1
+       AND pe.published_at IS NOT NULL
+       AND m.status = 'ready'
+     ORDER BY pe.air_date DESC
+     LIMIT 1`,
+    [stationId],
+  );
+
+  if (!episode?.manifest_url) return null;
+
+  // Load manifest from storage
+  const storage = getStorageAdapter();
+  const manifestBuffer = await storage.read(episode.manifest_url);
+  const manifest: ProgramManifest = JSON.parse(manifestBuffer.toString());
+
+  const state: PlayoutState = {
+    stationId,
+    manifest,
+    startedAt: Date.now(),
+    currentSegmentIndex: 0,
+    isPlaying: true,
+  };
+
+  activePlayouts.set(stationId, state);
+  startAdvanceTimer(stationId);
+
+  return state;
+}
+
+/** Stop playout for a station. */
+export function stopPlayout(stationId: string) {
+  const state = activePlayouts.get(stationId);
+  if (state) {
+    state.isPlaying = false;
+    activePlayouts.delete(stationId);
+  }
+  const timer = advanceTimers.get(stationId);
+  if (timer) {
+    clearTimeout(timer);
+    advanceTimers.delete(stationId);
+  }
+}
+
+/** Get current playback state. */
+export function getNowPlaying(stationId: string): NowPlaying | null {
+  const state = activePlayouts.get(stationId);
+  if (!state || !state.isPlaying) return null;
+
+  const elapsedMs = Date.now() - state.startedAt;
+  const elapsedSec = elapsedMs / 1000;
+
+  // Find which segment we should be playing based on elapsed time
+  const segments = state.manifest.segments;
+  let idx = 0;
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].start_sec + segments[i].duration_sec > elapsedSec) {
+      idx = i;
+      break;
+    }
+    if (i === segments.length - 1) idx = i; // past the end
+  }
+
+  state.currentSegmentIndex = idx;
+  const segment = segments[idx];
+  const segmentElapsed = elapsedSec - segment.start_sec;
+  const remaining = segment.duration_sec - segmentElapsed;
+  const next = segments[idx + 1];
+
+  return { segment, elapsed_sec: segmentElapsed, remaining_sec: Math.max(0, remaining), next_segment: next };
+}
+
+/** Get list of active playout stations. */
+export function getActivePlayouts(): string[] {
+  return Array.from(activePlayouts.keys());
+}
+
+/** Get the manifest for an active playout. */
+export function getPlayoutManifest(stationId: string): ProgramManifest | null {
+  return activePlayouts.get(stationId)?.manifest ?? null;
+}
+
+// ── Advance timer: fires when current segment ends ──────────────────────────
+
+const advanceTimers = new Map<string, NodeJS.Timeout>();
+
+function startAdvanceTimer(stationId: string) {
+  const state = activePlayouts.get(stationId);
+  if (!state || !state.isPlaying) return;
+
+  const segments = state.manifest.segments;
+  const segment = segments[state.currentSegmentIndex];
+  if (!segment) return;
+
+  const elapsedMs = Date.now() - state.startedAt;
+  const segmentEndMs = (segment.start_sec + segment.duration_sec) * 1000;
+  const delay = Math.max(0, segmentEndMs - elapsedMs);
+
+  // Notify about current segment immediately
+  const next = segments[state.currentSegmentIndex + 1];
+  notifyListeners(stationId, segment, next);
+
+  const timer = setTimeout(() => {
+    const s = activePlayouts.get(stationId);
+    if (!s || !s.isPlaying) return;
+
+    s.currentSegmentIndex++;
+    if (s.currentSegmentIndex >= segments.length) {
+      // End of manifest — stop playout
+      stopPlayout(stationId);
+      return;
+    }
+
+    startAdvanceTimer(stationId); // Schedule next transition
+  }, delay);
+
+  advanceTimers.set(stationId, timer);
+}

--- a/services/dj/src/playout/streamRoutes.ts
+++ b/services/dj/src/playout/streamRoutes.ts
@@ -1,0 +1,130 @@
+import type { FastifyInstance } from 'fastify';
+import fs from 'fs';
+import path from 'path';
+import {
+  startPlayout,
+  stopPlayout,
+  getNowPlaying,
+  getActivePlayouts,
+} from './playoutScheduler.js';
+import { generateHls, cleanupHls } from './hlsGenerator.js';
+
+const HLS_OUTPUT_DIR = process.env.HLS_OUTPUT_PATH || path.join(process.cwd(), 'data', 'hls');
+
+/**
+ * Stream/playout routes — serves HLS content and playout control.
+ * These are public routes (no auth) for OwnRadio consumption.
+ */
+export async function streamRoutes(app: FastifyInstance) {
+  // ── Playout control (internal) ──────────────────────────────────────────────
+
+  /** Start playout for a station. Loads latest published manifest and begins streaming. */
+  app.post('/internal/playout/:stationId/start', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+
+    const state = await startPlayout(stationId);
+    if (!state) {
+      return reply.code(404).send({ error: 'No published manifest found for station' });
+    }
+
+    // Generate HLS segments from the manifest
+    try {
+      const hls = await generateHls(stationId, state.manifest);
+      return { status: 'started', segments: hls.totalSegments, duration_sec: state.manifest.total_duration_sec };
+    } catch (err) {
+      stopPlayout(stationId);
+      return reply.code(500).send({ error: `HLS generation failed: ${(err as Error).message}` });
+    }
+  });
+
+  /** Stop playout for a station. */
+  app.post('/internal/playout/:stationId/stop', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+    stopPlayout(stationId);
+    await cleanupHls(stationId);
+    return reply.code(204).send();
+  });
+
+  /** Get now-playing info for a station. */
+  app.get('/internal/playout/:stationId/now-playing', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+    const nowPlaying = getNowPlaying(stationId);
+    if (!nowPlaying) return reply.code(404).send({ error: 'Station not playing' });
+    return nowPlaying;
+  });
+
+  /** List active playouts. */
+  app.get('/internal/playout/active', async () => {
+    return { stations: getActivePlayouts() };
+  });
+
+  // ── Public HLS streaming ────────────────────────────────────────────────────
+
+  /** Serve HLS playlist (.m3u8) for a station. */
+  app.get('/stream/:stationId/playlist.m3u8', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+    const playlistPath = path.join(HLS_OUTPUT_DIR, stationId, 'playlist.m3u8');
+
+    if (!fs.existsSync(playlistPath)) {
+      return reply.code(404).send({ error: 'Stream not available' });
+    }
+
+    const content = await fs.promises.readFile(playlistPath, 'utf-8');
+    return reply
+      .header('Content-Type', 'application/vnd.apple.mpegurl')
+      .header('Cache-Control', 'no-cache, no-store')
+      .header('Access-Control-Allow-Origin', '*')
+      .send(content);
+  });
+
+  /** Serve HLS segment (.ts) for a station. */
+  app.get('/stream/:stationId/:segment', async (req, reply) => {
+    const { stationId, segment } = req.params as { stationId: string; segment: string };
+
+    if (!segment.endsWith('.ts')) {
+      return reply.code(400).send({ error: 'Invalid segment' });
+    }
+
+    const segmentPath = path.join(HLS_OUTPUT_DIR, stationId, segment);
+    if (!fs.existsSync(segmentPath)) {
+      return reply.code(404).send({ error: 'Segment not found' });
+    }
+
+    const stream = fs.createReadStream(segmentPath);
+    return reply
+      .header('Content-Type', 'video/mp2t')
+      .header('Cache-Control', 'public, max-age=3600')
+      .header('Access-Control-Allow-Origin', '*')
+      .send(stream);
+  });
+
+  // ── Now-playing metadata API (public, for OwnRadio polling) ─────────────────
+
+  /** Get current track metadata — compatible with Icecast JSON format for OwnRadio. */
+  app.get('/stream/:stationId/metadata', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+    const nowPlaying = getNowPlaying(stationId);
+
+    if (!nowPlaying) {
+      return reply.code(404).send({ error: 'Station not playing' });
+    }
+
+    // Return in Icecast-compatible format for OwnRadio compatibility
+    return reply
+      .header('Access-Control-Allow-Origin', '*')
+      .send({
+        icestats: {
+          source: {
+            title: `${nowPlaying.segment.metadata.artist} - ${nowPlaying.segment.metadata.title}`,
+          },
+        },
+        // Extended metadata for direct integration
+        playgen: {
+          segment: nowPlaying.segment,
+          elapsed_sec: nowPlaying.elapsed_sec,
+          remaining_sec: nowPlaying.remaining_sec,
+          next: nowPlaying.next_segment?.metadata,
+        },
+      });
+  });
+}

--- a/services/dj/src/routes/manifests.ts
+++ b/services/dj/src/routes/manifests.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from 'fastify';
+import { buildProgramManifest, getManifestByScript } from '../services/manifestService.js';
+
+/**
+ * Internal manifest routes — not exposed through the gateway.
+ * Called by station-service during publish.
+ */
+export async function manifestRoutes(app: FastifyInstance) {
+  // Build program manifest for an episode
+  app.post('/internal/manifests/build', async (req, reply) => {
+    const { episode_id } = req.body as { episode_id: string };
+    if (!episode_id) return reply.code(400).send({ error: 'episode_id required' });
+
+    const manifest = await buildProgramManifest(episode_id);
+    return {
+      manifest_url: `manifests/${episode_id}.json`,
+      total_duration_sec: manifest.total_duration_sec,
+    };
+  });
+
+  // Get manifest by script ID
+  app.get('/internal/manifests/by-script/:scriptId', async (req, reply) => {
+    const { scriptId } = req.params as { scriptId: string };
+    const manifest = await getManifestByScript(scriptId);
+    if (!manifest) return reply.code(404).send({ error: 'Manifest not found' });
+    return manifest;
+  });
+}

--- a/services/dj/src/services/manifestService.ts
+++ b/services/dj/src/services/manifestService.ts
@@ -13,6 +13,29 @@ export interface ManifestItem {
   cumulative_ms: number;
 }
 
+export interface ProgramManifestSegment {
+  position: number;
+  type: 'song' | 'dj_segment' | 'station_id' | 'weather' | 'news' | 'joke' | 'ad_break' | 'time_check' | 'adlib' | 'listener_activity';
+  segment_type?: string;
+  start_sec: number;
+  duration_sec: number;
+  audio_url: string | null;
+  script_text?: string;
+  song?: { id: string; title: string; artist: string };
+  dj_profile?: { name: string };
+  metadata: { title: string; artist: string };
+}
+
+export interface ProgramManifest {
+  version: 1;
+  station_id: string;
+  episode_id: string;
+  air_date: string;
+  dj_profile?: { id: string; name: string; voice_style: string };
+  total_duration_sec: number;
+  segments: ProgramManifestSegment[];
+}
+
 export interface ShowManifest {
   total_duration_ms: number;
   items: ManifestItem[];
@@ -142,4 +165,206 @@ export async function getManifestByScript(scriptId: string) {
     [scriptId]
   );
   return rows[0] || null;
+}
+
+/**
+ * Build a full program manifest for an episode, including song audio URLs
+ * and all segment types (DJ, weather, news, jokes, station IDs, ads, etc.).
+ *
+ * This is the enhanced version used by the Publish feature to produce a
+ * complete, streamable program for OwnRadio consumption.
+ */
+export async function buildProgramManifest(episodeId: string): Promise<ProgramManifest> {
+  const pool = getPool();
+
+  // 1. Load episode with program and DJ profile
+  const { rows: [episode] } = await pool.query(
+    `SELECT pe.*, p.name AS program_name, p.start_hour, p.end_hour, p.dj_profile_id,
+            dp.name AS dj_name, dp.voice_style AS dj_voice_style
+     FROM program_episodes pe
+     JOIN programs p ON p.id = pe.program_id
+     LEFT JOIN dj_profiles dp ON dp.id = p.dj_profile_id
+     WHERE pe.id = $1`,
+    [episodeId],
+  );
+  if (!episode) throw new Error(`Episode ${episodeId} not found`);
+
+  // 2. Load playlist entries with song audio
+  const { rows: entries } = await pool.query(
+    `SELECT pe.id, pe.hour, pe.position, s.id AS song_id, s.title, s.artist,
+            s.duration_sec, s.audio_url AS song_audio_url
+     FROM playlist_entries pe
+     JOIN songs s ON s.id = pe.song_id
+     WHERE pe.playlist_id = $1
+     ORDER BY pe.hour, pe.position`,
+    [episode.playlist_id],
+  );
+
+  // 3. Load DJ segments (both playlist-bound and standalone)
+  const { rows: segments } = await pool.query(
+    `SELECT ds.*, ds.edited_text AS display_text
+     FROM dj_segments ds
+     WHERE ds.script_id = $1
+     ORDER BY ds.position`,
+    [episode.dj_script_id],
+  );
+
+  // 4. Build segment map: playlist_entry_id -> segments
+  const entrySegmentMap = new Map<string, typeof segments>();
+  const standaloneSegments: typeof segments = [];
+  for (const seg of segments) {
+    if (seg.playlist_entry_id) {
+      const list = entrySegmentMap.get(seg.playlist_entry_id) || [];
+      list.push(seg);
+      entrySegmentMap.set(seg.playlist_entry_id, list);
+    } else {
+      standaloneSegments.push(seg);
+    }
+  }
+
+  // 5. Interleave into ordered manifest
+  const manifestSegments: ProgramManifestSegment[] = [];
+  let cumulativeSec = 0;
+  let pos = 0;
+
+  const addSegment = (seg: ProgramManifestSegment) => {
+    manifestSegments.push(seg);
+    cumulativeSec += seg.duration_sec;
+    pos++;
+  };
+
+  // Insert standalone segments that belong before any song (show_intro, station_id at position 0, etc.)
+  const preShowSegments = standaloneSegments.filter(s =>
+    s.segment_type === 'show_intro' || s.segment_type === 'station_id' && s.position === 0,
+  );
+  for (const seg of preShowSegments) {
+    addSegment(makeSegmentEntry(seg, pos, cumulativeSec, episode.dj_name));
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const entrySegs = entrySegmentMap.get(entry.id) || [];
+
+    // DJ segments before the song (intro, transition, weather, etc.)
+    const beforeSegs = entrySegs.filter(s => s.segment_type !== 'show_outro');
+    for (const seg of beforeSegs) {
+      addSegment(makeSegmentEntry(seg, pos, cumulativeSec, episode.dj_name));
+    }
+
+    // The song itself
+    const songDuration = entry.duration_sec || 0;
+    addSegment({
+      position: pos,
+      type: 'song',
+      start_sec: cumulativeSec,
+      duration_sec: songDuration,
+      audio_url: entry.song_audio_url,
+      song: { id: entry.song_id, title: entry.title, artist: entry.artist },
+      metadata: { title: entry.title, artist: entry.artist },
+    });
+
+    // show_outro after last song
+    if (i === entries.length - 1) {
+      const outroSegs = entrySegs.filter(s => s.segment_type === 'show_outro');
+      for (const seg of outroSegs) {
+        addSegment(makeSegmentEntry(seg, pos, cumulativeSec, episode.dj_name));
+      }
+    }
+  }
+
+  // Add remaining standalone segments (those not already added)
+  const usedIds = new Set(preShowSegments.map(s => s.id));
+  for (const seg of standaloneSegments) {
+    if (!usedIds.has(seg.id)) {
+      addSegment(makeSegmentEntry(seg, pos, cumulativeSec, episode.dj_name));
+    }
+  }
+
+  const manifest: ProgramManifest = {
+    version: 1,
+    station_id: episode.station_id || '',
+    episode_id: episodeId,
+    air_date: episode.air_date,
+    dj_profile: episode.dj_profile_id ? {
+      id: episode.dj_profile_id,
+      name: episode.dj_name || 'DJ',
+      voice_style: episode.dj_voice_style || 'energetic',
+    } : undefined,
+    total_duration_sec: cumulativeSec,
+    segments: manifestSegments,
+  };
+
+  // 6. Save manifest to storage
+  const storage = getStorageAdapter();
+  const manifestPath = `manifests/${episodeId}.json`;
+  await storage.write(manifestPath, Buffer.from(JSON.stringify(manifest, null, 2)));
+  const manifestUrl = storage.getPublicUrl(manifestPath);
+
+  // 7. Update or create dj_show_manifests record
+  if (episode.dj_script_id) {
+    await pool.query(
+      `INSERT INTO dj_show_manifests (script_id, station_id, status, manifest_url, total_duration_sec, built_at)
+       VALUES ($1, $2, 'ready', $3, $4, NOW())
+       ON CONFLICT (script_id) DO UPDATE SET
+         status = 'ready', manifest_url = $3, total_duration_sec = $4, built_at = NOW(), updated_at = NOW()`,
+      [episode.dj_script_id, manifest.station_id, manifestUrl, cumulativeSec],
+    );
+  }
+
+  // 8. Link manifest to episode
+  const { rows: [manifestRow] } = await pool.query(
+    `SELECT id FROM dj_show_manifests WHERE script_id = $1`,
+    [episode.dj_script_id],
+  );
+  if (manifestRow) {
+    await pool.query(
+      `UPDATE program_episodes SET manifest_id = $1, updated_at = NOW() WHERE id = $2`,
+      [manifestRow.id, episodeId],
+    );
+  }
+
+  return manifest;
+}
+
+/** Map a DJ segment DB row to a ProgramManifestSegment. */
+function makeSegmentEntry(
+  seg: Record<string, unknown>,
+  position: number,
+  startSec: number,
+  djName?: string,
+): ProgramManifestSegment {
+  const segType = seg.segment_type as string;
+  const durationSec = parseFloat(String(seg.audio_duration_sec || 0));
+  const displayText = (seg.display_text || seg.script_text || '') as string;
+
+  // Map segment_type to manifest type
+  const typeMap: Record<string, ProgramManifestSegment['type']> = {
+    show_intro: 'dj_segment',
+    show_outro: 'dj_segment',
+    song_intro: 'dj_segment',
+    song_transition: 'dj_segment',
+    station_id: 'station_id',
+    time_check: 'time_check',
+    weather_tease: 'weather',
+    current_events: 'news',
+    joke: 'joke',
+    ad_break: 'ad_break',
+    adlib: 'adlib',
+    listener_activity: 'listener_activity',
+  };
+
+  return {
+    position,
+    type: typeMap[segType] || 'dj_segment',
+    segment_type: segType,
+    start_sec: startSec,
+    duration_sec: durationSec,
+    audio_url: (seg.audio_url as string) || null,
+    script_text: displayText || undefined,
+    dj_profile: djName ? { name: djName } : undefined,
+    metadata: {
+      title: `${segType.replace(/_/g, ' ')}`,
+      artist: djName || 'DJ',
+    },
+  };
 }

--- a/services/library/src/routes/songs.ts
+++ b/services/library/src/routes/songs.ts
@@ -6,6 +6,8 @@ import { pipeline } from 'stream/promises';
 import { authenticate, requirePermission, requireStationAccess } from '@playgen/middleware';
 import * as songService from '../services/songService';
 import { importXlsmSongs, importXlsmLoadHistory } from '../services/importService';
+import { storeAudioStream } from '../services/audioStorageService';
+import { sourceFromYouTube, bulkSourceFromYouTube, bulkImportFromDirectory } from '../services/audioSourceService';
 
 export async function songRoutes(app: FastifyInstance) {
   app.addHook('onRequest', authenticate);
@@ -103,5 +105,74 @@ export async function songRoutes(app: FastifyInstance) {
     } finally {
       fs.unlink(tmpPath, () => {});
     }
+  });
+
+  // ── Audio upload for a single song ──────────────────────────────────────────
+  app.post('/songs/:id/upload-audio', {
+    onRequest: [requirePermission('library:write')],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const song = await songService.getSong(id);
+    if (!song) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Song not found' } });
+
+    const data = await req.file();
+    if (!data) return reply.code(400).send({ error: { code: 'BAD_REQUEST', message: 'No file uploaded' } });
+
+    const ext = path.extname(data.filename).toLowerCase();
+    const allowed = new Set(['.mp3', '.flac', '.wav', '.aac', '.ogg', '.m4a', '.opus']);
+    if (!allowed.has(ext)) {
+      return reply.code(400).send({ error: { code: 'BAD_REQUEST', message: `Unsupported format: ${ext}` } });
+    }
+
+    const { audioUrl, durationSec } = await storeAudioStream(song.station_id, id, data.file, ext);
+
+    const updated = await songService.updateSong(id, {
+      ...(durationSec != null ? { duration_sec: durationSec } : {}),
+    });
+
+    // Update audio_url and audio_source directly (not in songService.updateSong's allowed list yet)
+    const { getPool } = await import('../db');
+    await getPool().query(
+      `UPDATE songs SET audio_url = $1, audio_source = 'upload', updated_at = NOW() WHERE id = $2`,
+      [audioUrl, id],
+    );
+
+    return reply.code(200).send({ audio_url: audioUrl, duration_sec: durationSec, song: updated });
+  });
+
+  // ── Source audio from YouTube (single song) ─────────────────────────────────
+  app.post('/songs/:id/source-audio', {
+    onRequest: [requirePermission('library:write')],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const song = await songService.getSong(id);
+    if (!song) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Song not found' } });
+
+    const result = await sourceFromYouTube(id, song.station_id, song.title, song.artist);
+    return reply.code(200).send(result);
+  });
+
+  // ── Bulk source audio from YouTube (all missing in station) ─────────────────
+  app.post('/stations/:id/songs/source-audio', {
+    onRequest: [requirePermission('library:write'), requireStationAccess()],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const query = req.query as { limit?: string };
+    const limit = query.limit ? parseInt(query.limit, 10) : 50;
+
+    const result = await bulkSourceFromYouTube(id, { limit });
+    return reply.code(200).send(result);
+  });
+
+  // ── Bulk import from local directory ────────────────────────────────────────
+  app.post('/stations/:id/songs/import-directory', {
+    onRequest: [requirePermission('library:write'), requireStationAccess()],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { directory } = req.body as { directory: string };
+    if (!directory) return reply.code(400).send({ error: { code: 'BAD_REQUEST', message: 'directory path required' } });
+
+    const result = await bulkImportFromDirectory(id, directory);
+    return reply.code(200).send(result);
   });
 }

--- a/services/library/src/services/audioSourceService.ts
+++ b/services/library/src/services/audioSourceService.ts
@@ -1,0 +1,148 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { getPool } from '../db';
+import { storeAudioFile } from './audioStorageService';
+
+const execFileAsync = promisify(execFile);
+
+const YT_DLP = process.env.YT_DLP_PATH || 'yt-dlp';
+
+interface SourceResult {
+  songId: string;
+  audioUrl: string;
+  durationSec: number | null;
+  source: string;
+}
+
+/**
+ * Download audio for a single song from YouTube via yt-dlp.
+ * Searches by "{artist} - {title}" and downloads the best audio.
+ */
+export async function sourceFromYouTube(
+  songId: string,
+  stationId: string,
+  title: string,
+  artist: string,
+): Promise<SourceResult> {
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'playgen-ytdl-'));
+  const outputTemplate = path.join(tmpDir, '%(id)s.%(ext)s');
+  const searchQuery = `${artist} - ${title}`;
+
+  try {
+    await execFileAsync(YT_DLP, [
+      `ytsearch1:${searchQuery}`,
+      '--extract-audio',
+      '--audio-format', 'mp3',
+      '--audio-quality', '192K',
+      '--no-playlist',
+      '--max-downloads', '1',
+      '--output', outputTemplate,
+      '--no-warnings',
+      '--quiet',
+    ], { timeout: 120_000 });
+
+    // Find the downloaded file
+    const files = await fs.promises.readdir(tmpDir);
+    const audioFile = files.find(f => f.endsWith('.mp3') || f.endsWith('.opus') || f.endsWith('.m4a'));
+    if (!audioFile) throw new Error(`yt-dlp produced no audio file for "${searchQuery}"`);
+
+    const sourcePath = path.join(tmpDir, audioFile);
+    const { audioUrl, durationSec } = await storeAudioFile(stationId, songId, sourcePath);
+
+    // Update database
+    await getPool().query(
+      `UPDATE songs SET audio_url = $1, audio_source = 'youtube', duration_sec = COALESCE($2, duration_sec), updated_at = NOW() WHERE id = $3`,
+      [audioUrl, durationSec, songId],
+    );
+
+    return { songId, audioUrl, durationSec, source: 'youtube' };
+  } finally {
+    fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Bulk-source audio for all songs in a station that are missing audio_url.
+ * Processes sequentially to avoid rate-limiting.
+ */
+export async function bulkSourceFromYouTube(
+  stationId: string,
+  opts: { limit?: number } = {},
+): Promise<{ sourced: number; failed: number; errors: Array<{ songId: string; error: string }> }> {
+  const limit = opts.limit ?? 50;
+  const { rows } = await getPool().query<{ id: string; title: string; artist: string }>(
+    `SELECT id, title, artist FROM songs
+     WHERE station_id = $1 AND is_active = TRUE AND audio_url IS NULL
+     ORDER BY artist, title
+     LIMIT $2`,
+    [stationId, limit],
+  );
+
+  let sourced = 0;
+  let failed = 0;
+  const errors: Array<{ songId: string; error: string }> = [];
+
+  for (const song of rows) {
+    try {
+      await sourceFromYouTube(song.id, stationId, song.title, song.artist);
+      sourced++;
+    } catch (err) {
+      failed++;
+      errors.push({ songId: song.id, error: (err as Error).message });
+    }
+  }
+
+  return { sourced, failed, errors };
+}
+
+/**
+ * Scan a local directory for audio files and match them to songs by filename.
+ * Expected filename pattern: "{artist} - {title}.mp3"
+ */
+export async function bulkImportFromDirectory(
+  stationId: string,
+  dirPath: string,
+): Promise<{ matched: number; unmatched: string[] }> {
+  const entries = await fs.promises.readdir(dirPath);
+  const audioExts = new Set(['.mp3', '.flac', '.wav', '.aac', '.ogg', '.m4a', '.opus']);
+
+  let matched = 0;
+  const unmatched: string[] = [];
+
+  for (const entry of entries) {
+    const ext = path.extname(entry).toLowerCase();
+    if (!audioExts.has(ext)) continue;
+
+    const basename = path.basename(entry, ext);
+    const sepIdx = basename.indexOf(' - ');
+    if (sepIdx === -1) { unmatched.push(entry); continue; }
+
+    const artist = basename.slice(0, sepIdx).trim();
+    const title = basename.slice(sepIdx + 3).trim();
+
+    // Find matching song (case-insensitive)
+    const { rows } = await getPool().query<{ id: string }>(
+      `SELECT id FROM songs
+       WHERE station_id = $1 AND LOWER(artist) = LOWER($2) AND LOWER(title) = LOWER($3)
+       LIMIT 1`,
+      [stationId, artist, title],
+    );
+
+    if (!rows[0]) { unmatched.push(entry); continue; }
+
+    const sourcePath = path.join(dirPath, entry);
+    const { audioUrl, durationSec } = await storeAudioFile(stationId, rows[0].id, sourcePath);
+
+    await getPool().query(
+      `UPDATE songs SET audio_url = $1, audio_source = 'upload', duration_sec = COALESCE($2, duration_sec), updated_at = NOW() WHERE id = $3`,
+      [audioUrl, durationSec, rows[0].id],
+    );
+
+    matched++;
+  }
+
+  return { matched, unmatched };
+}

--- a/services/library/src/services/audioStorageService.ts
+++ b/services/library/src/services/audioStorageService.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const AUDIO_BASE_DIR = process.env.AUDIO_STORAGE_PATH || path.join(process.cwd(), 'data', 'audio', 'songs');
+
+/** Ensure the storage directory for a station exists. */
+function stationDir(stationId: string): string {
+  const dir = path.join(AUDIO_BASE_DIR, stationId);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Store an audio file for a song. Returns the relative storage path. */
+export async function storeAudioFile(
+  stationId: string,
+  songId: string,
+  sourcePath: string,
+): Promise<{ audioUrl: string; durationSec: number | null }> {
+  const ext = path.extname(sourcePath) || '.mp3';
+  const destFilename = `${songId}${ext}`;
+  const destPath = path.join(stationDir(stationId), destFilename);
+
+  await fs.promises.copyFile(sourcePath, destPath);
+
+  const durationSec = await probeDuration(destPath);
+  const audioUrl = path.relative(AUDIO_BASE_DIR, destPath);
+  return { audioUrl, durationSec };
+}
+
+/** Store audio from a readable stream (multipart upload). */
+export async function storeAudioStream(
+  stationId: string,
+  songId: string,
+  stream: NodeJS.ReadableStream,
+  ext: string,
+): Promise<{ audioUrl: string; durationSec: number | null }> {
+  const destFilename = `${songId}${ext}`;
+  const destPath = path.join(stationDir(stationId), destFilename);
+
+  await new Promise<void>((resolve, reject) => {
+    const ws = fs.createWriteStream(destPath);
+    stream.pipe(ws);
+    ws.on('finish', resolve);
+    ws.on('error', reject);
+  });
+
+  const durationSec = await probeDuration(destPath);
+  const audioUrl = path.relative(AUDIO_BASE_DIR, destPath);
+  return { audioUrl, durationSec };
+}
+
+/** Get the full filesystem path for an audio URL. */
+export function resolveAudioPath(audioUrl: string): string {
+  return path.join(AUDIO_BASE_DIR, audioUrl);
+}
+
+/** Probe audio duration using ffprobe. Returns seconds or null if ffprobe unavailable. */
+export async function probeDuration(filePath: string): Promise<number | null> {
+  try {
+    const { stdout } = await execFileAsync('ffprobe', [
+      '-v', 'quiet',
+      '-print_format', 'json',
+      '-show_format',
+      filePath,
+    ]);
+    const info = JSON.parse(stdout);
+    const dur = parseFloat(info.format?.duration);
+    return Number.isFinite(dur) ? Math.round(dur) : null;
+  } catch {
+    return null;
+  }
+}

--- a/services/scheduler/src/index.ts
+++ b/services/scheduler/src/index.ts
@@ -7,6 +7,7 @@ import { schedulerRoutes } from './routes/scheduler';
 import { configRoutes } from './routes/config';
 import { startCron, stopCron } from './services/cronService';
 import { closeQueue } from './services/queueService';
+import { scheduleDailyGeneration, stopDailyGeneration } from './jobs/dailyProgramJob';
 
 const app = Fastify({
   logger: {
@@ -54,6 +55,7 @@ async function shutdown(signal: string): Promise<void> {
   app.log.info(`Received ${signal}, shutting down gracefully`);
   try {
     stopCron();
+    stopDailyGeneration();
     await closeQueue();
     await app.close();
     process.exit(0);
@@ -77,6 +79,7 @@ app.listen({ port, host }, (err) => {
     process.exit(1);
   }
   startCron();
+  scheduleDailyGeneration();
   app.log.info(`scheduler-service listening on port ${port}`);
 });
 

--- a/services/scheduler/src/index.ts
+++ b/services/scheduler/src/index.ts
@@ -7,7 +7,7 @@ import { schedulerRoutes } from './routes/scheduler';
 import { configRoutes } from './routes/config';
 import { startCron, stopCron } from './services/cronService';
 import { closeQueue } from './services/queueService';
-import { scheduleDailyGeneration, stopDailyGeneration } from './jobs/dailyProgramJob';
+import { dailyProgramRoutes } from './routes/dailyProgram';
 
 const app = Fastify({
   logger: {
@@ -30,6 +30,7 @@ app.get('/health', async () => ({ status: 'ok', service: 'scheduler-service' }))
 
 app.register(schedulerRoutes, { prefix: '/api/v1' });
 app.register(configRoutes, { prefix: '/api/v1' });
+app.register(dailyProgramRoutes, { prefix: '/api/v1' });
 
 // ── Error handler ─────────────────────────────────────────────────────────────
 
@@ -55,7 +56,6 @@ async function shutdown(signal: string): Promise<void> {
   app.log.info(`Received ${signal}, shutting down gracefully`);
   try {
     stopCron();
-    stopDailyGeneration();
     await closeQueue();
     await app.close();
     process.exit(0);
@@ -79,7 +79,6 @@ app.listen({ port, host }, (err) => {
     process.exit(1);
   }
   startCron();
-  scheduleDailyGeneration();
   app.log.info(`scheduler-service listening on port ${port}`);
 });
 

--- a/services/scheduler/src/jobs/dailyProgramJob.ts
+++ b/services/scheduler/src/jobs/dailyProgramJob.ts
@@ -1,4 +1,3 @@
-import cron, { ScheduledTask } from 'node-cron';
 import { getPool } from '../db';
 import { enqueueGeneration } from '../services/queueService';
 import { getDayOfWeek } from '../services/generationEngine';
@@ -11,11 +10,7 @@ interface ActiveProgram {
   template_id: string | null;
 }
 
-// ─── Cron state ───────────────────────────────────────────────────────────────
-
-let _scheduledTask: ScheduledTask | null = null;
-
-// ─── Core tick handler ────────────────────────────────────────────────────────
+// ─── Core generation handler ─────────────────────────────────────────────────
 
 /**
  * Query active programs for tomorrow's day-of-week and enqueue playlist
@@ -116,44 +111,60 @@ export async function runDailyProgramGeneration(): Promise<void> {
   );
 }
 
-// ─── Schedule registration ────────────────────────────────────────────────────
-
 /**
- * Register the daily program generation cron job using BullMQ's node-cron
- * compatible expression.
- *
- * Hour is configurable via DAILY_GENERATION_HOUR (0–23, default 2).
- * Full expression can be overridden with DAILY_PROGRAM_CRON.
+ * Run daily generation for a specific date (defaults to tomorrow).
+ * Returns summary of what was queued.
  */
-export function scheduleDailyGeneration(): void {
-  if (_scheduledTask) {
-    console.warn('[dailyProgramJob] Already scheduled — ignoring duplicate call');
-    return;
+export async function runDailyProgramGenerationForDate(
+  targetDate?: string,
+): Promise<{ date: string; queued: number; skipped: number }> {
+  const date = targetDate ?? getDefaultTargetDate();
+  const dayOfWeek = getDayOfWeek(date);
+
+  console.info(`[dailyProgramJob] Triggered for date=${date} dayOfWeek=${dayOfWeek}`);
+
+  const pool = getPool();
+
+  const { rows: programs } = await pool.query<ActiveProgram>(
+    `SELECT p.id, p.station_id, p.template_id
+     FROM programs p
+     WHERE p.is_active = TRUE AND $1 = ANY(p.active_days)`,
+    [dayOfWeek],
+  );
+
+  if (programs.length === 0) {
+    return { date, queued: 0, skipped: 0 };
   }
 
-  const hour = Number(process.env.DAILY_GENERATION_HOUR ?? 2);
-  const expression = process.env.DAILY_PROGRAM_CRON ?? `0 ${hour} * * *`;
+  const stationIds = [...new Set(programs.map(p => p.station_id))];
+  const { rows: existing } = await pool.query<{ station_id: string }>(
+    `SELECT station_id FROM playlists
+     WHERE date = $1 AND station_id = ANY($2)
+       AND status IN ('approved', 'ready', 'generating')`,
+    [date, stationIds],
+  );
+  const skipSet = new Set(existing.map(r => r.station_id));
 
-  if (!cron.validate(expression)) {
-    throw new Error(`[dailyProgramJob] Invalid cron expression: "${expression}"`);
-  }
+  let queued = 0;
+  let skipped = 0;
 
-  _scheduledTask = cron.schedule(expression, () => {
-    runDailyProgramGeneration().catch((err) => {
-      console.error('[dailyProgramJob] Unhandled error in runDailyProgramGeneration', err);
+  for (const program of programs) {
+    if (skipSet.has(program.station_id)) { skipped++; continue; }
+    await enqueueGeneration({
+      stationId: program.station_id,
+      date,
+      templateId: program.template_id ?? undefined,
+      triggeredBy: 'cron',
     });
-  });
+    queued++;
+    skipSet.add(program.station_id);
+  }
 
-  console.info(`[dailyProgramJob] Scheduled with expression="${expression}"`);
+  return { date, queued, skipped };
 }
 
-/**
- * Stop the daily program generation cron job. Called on graceful shutdown.
- */
-export function stopDailyGeneration(): void {
-  if (_scheduledTask) {
-    _scheduledTask.stop();
-    _scheduledTask = null;
-    console.info('[dailyProgramJob] Stopped');
-  }
+function getDefaultTargetDate(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().slice(0, 10);
 }

--- a/services/scheduler/src/jobs/dailyProgramJob.ts
+++ b/services/scheduler/src/jobs/dailyProgramJob.ts
@@ -1,0 +1,159 @@
+import cron, { ScheduledTask } from 'node-cron';
+import { getPool } from '../db';
+import { enqueueGeneration } from '../services/queueService';
+import { getDayOfWeek } from '../services/generationEngine';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ActiveProgram {
+  id: string;
+  station_id: string;
+  template_id: string | null;
+}
+
+// ─── Cron state ───────────────────────────────────────────────────────────────
+
+let _scheduledTask: ScheduledTask | null = null;
+
+// ─── Core tick handler ────────────────────────────────────────────────────────
+
+/**
+ * Query active programs for tomorrow's day-of-week and enqueue playlist
+ * generation for each one that does not yet have a playlist in a terminal
+ * or in-progress state.
+ */
+export async function runDailyProgramGeneration(): Promise<void> {
+  const pool = getPool();
+
+  // ── Calculate tomorrow ────────────────────────────────────────────────────
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const targetDate = tomorrow.toISOString().slice(0, 10);
+  const dayOfWeek = getDayOfWeek(targetDate);
+
+  console.info(
+    `[dailyProgramJob] Daily generation tick — targetDate=${targetDate} dayOfWeek=${dayOfWeek}`,
+  );
+
+  // ── Load active programs for tomorrow's day-of-week ───────────────────────
+  let programs: ActiveProgram[];
+  try {
+    const res = await pool.query<ActiveProgram>(
+      `SELECT p.id, p.station_id, p.template_id
+       FROM programs p
+       WHERE p.is_active = TRUE
+         AND $1 = ANY(p.active_days)`,
+      [dayOfWeek],
+    );
+    programs = res.rows;
+  } catch (err) {
+    console.error('[dailyProgramJob] Failed to query active programs', err);
+    return;
+  }
+
+  if (programs.length === 0) {
+    console.info(`[dailyProgramJob] No active programs for ${dayOfWeek} — nothing to enqueue`);
+    return;
+  }
+
+  // ── Load existing playlists for targetDate to implement idempotency ───────
+  // A playlist in 'approved', 'ready', or 'generating' state is considered
+  // already handled; only skip those. A 'failed' playlist is re-queued so it
+  // gets another attempt.
+  const stationIds = [...new Set(programs.map((p) => p.station_id))];
+  let skipSet: Set<string>;
+  try {
+    const existingRes = await pool.query<{ station_id: string; status: string }>(
+      `SELECT station_id, status
+       FROM playlists
+       WHERE date = $1
+         AND station_id = ANY($2)
+         AND status IN ('approved', 'ready', 'generating')`,
+      [targetDate, stationIds],
+    );
+    skipSet = new Set(existingRes.rows.map((r) => r.station_id));
+  } catch (err) {
+    console.error('[dailyProgramJob] Failed to query existing playlists', err);
+    return;
+  }
+
+  // ── Enqueue generation for each eligible program ──────────────────────────
+  let queued = 0;
+  let skipped = 0;
+
+  for (const program of programs) {
+    if (skipSet.has(program.station_id)) {
+      console.info(
+        `[dailyProgramJob] Skipping program=${program.id} station=${program.station_id} — playlist already exists for ${targetDate}`,
+      );
+      skipped++;
+      continue;
+    }
+
+    try {
+      const jobId = await enqueueGeneration({
+        stationId: program.station_id,
+        date: targetDate,
+        templateId: program.template_id ?? undefined,
+        triggeredBy: 'cron',
+      });
+      console.info(
+        `[dailyProgramJob] Enqueued job=${jobId} program=${program.id} station=${program.station_id} date=${targetDate}`,
+      );
+      queued++;
+      // Mark station as handled for subsequent programs on the same station
+      skipSet.add(program.station_id);
+    } catch (err) {
+      console.error(
+        `[dailyProgramJob] Failed to enqueue program=${program.id} station=${program.station_id}`,
+        err,
+      );
+    }
+  }
+
+  console.info(
+    `[dailyProgramJob] Daily generation: queued ${queued} playlists for ${targetDate} (${skipped} skipped)`,
+  );
+}
+
+// ─── Schedule registration ────────────────────────────────────────────────────
+
+/**
+ * Register the daily program generation cron job using BullMQ's node-cron
+ * compatible expression.
+ *
+ * Hour is configurable via DAILY_GENERATION_HOUR (0–23, default 2).
+ * Full expression can be overridden with DAILY_PROGRAM_CRON.
+ */
+export function scheduleDailyGeneration(): void {
+  if (_scheduledTask) {
+    console.warn('[dailyProgramJob] Already scheduled — ignoring duplicate call');
+    return;
+  }
+
+  const hour = Number(process.env.DAILY_GENERATION_HOUR ?? 2);
+  const expression = process.env.DAILY_PROGRAM_CRON ?? `0 ${hour} * * *`;
+
+  if (!cron.validate(expression)) {
+    throw new Error(`[dailyProgramJob] Invalid cron expression: "${expression}"`);
+  }
+
+  _scheduledTask = cron.schedule(expression, () => {
+    runDailyProgramGeneration().catch((err) => {
+      console.error('[dailyProgramJob] Unhandled error in runDailyProgramGeneration', err);
+    });
+  });
+
+  console.info(`[dailyProgramJob] Scheduled with expression="${expression}"`);
+}
+
+/**
+ * Stop the daily program generation cron job. Called on graceful shutdown.
+ */
+export function stopDailyGeneration(): void {
+  if (_scheduledTask) {
+    _scheduledTask.stop();
+    _scheduledTask = null;
+    console.info('[dailyProgramJob] Stopped');
+  }
+}

--- a/services/scheduler/src/routes/dailyProgram.ts
+++ b/services/scheduler/src/routes/dailyProgram.ts
@@ -1,0 +1,46 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticate, requirePermission } from '@playgen/middleware';
+import {
+  runDailyProgramGenerationForDate,
+} from '../jobs/dailyProgramJob';
+
+export async function dailyProgramRoutes(app: FastifyInstance) {
+  app.addHook('onRequest', authenticate);
+
+  /**
+   * POST /daily-program/generate
+   *
+   * Trigger daily program generation on demand.
+   * Body: { date?: "YYYY-MM-DD" }  — defaults to tomorrow.
+   *
+   * Returns: { date, queued, skipped }
+   */
+  app.post('/daily-program/generate', {
+    onRequest: [requirePermission('playlist:write')],
+  }, async (req) => {
+    const { date } = (req.body as { date?: string }) ?? {};
+
+    if (date) {
+      // Validate date format
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        throw app.httpErrors.badRequest('date must be YYYY-MM-DD format');
+      }
+      return runDailyProgramGenerationForDate(date);
+    }
+
+    // Default: generate for tomorrow
+    return runDailyProgramGenerationForDate();
+  });
+
+  /**
+   * POST /daily-program/generate-today
+   *
+   * Convenience: generate for today (useful for testing / catch-up).
+   */
+  app.post('/daily-program/generate-today', {
+    onRequest: [requirePermission('playlist:write')],
+  }, async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    return runDailyProgramGenerationForDate(today);
+  });
+}

--- a/services/scheduler/tests/unit/dailyProgramJob.test.ts
+++ b/services/scheduler/tests/unit/dailyProgramJob.test.ts
@@ -22,7 +22,7 @@ vi.mock('../../src/services/queueService', () => ({
 
 import { getPool } from '../../src/db';
 import { enqueueGeneration } from '../../src/services/queueService';
-import { runDailyProgramGeneration, scheduleDailyGeneration, stopDailyGeneration } from '../../src/jobs/dailyProgramJob';
+import { runDailyProgramGeneration } from '../../src/jobs/dailyProgramJob';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -220,42 +220,26 @@ describe('runDailyProgramGeneration', () => {
   });
 });
 
-describe('scheduleDailyGeneration / stopDailyGeneration', () => {
-  afterEach(() => {
-    // Always stop after each test to reset module-level state
-    stopDailyGeneration();
-    delete process.env.DAILY_GENERATION_HOUR;
-    delete process.env.DAILY_PROGRAM_CRON;
-  });
+describe('runDailyProgramGenerationForDate', () => {
+  it('accepts a specific date and returns results', async () => {
+    const { runDailyProgramGenerationForDate } = await import('../../src/jobs/dailyProgramJob');
 
-  it('registers a cron task without throwing', () => {
-    expect(() => scheduleDailyGeneration()).not.toThrow();
-    // Confirm stop cleans up without throwing
-    expect(() => stopDailyGeneration()).not.toThrow();
-  });
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        return { rows: [{ id: 'prog-1', station_id: 'station-a', template_id: null }] };
+      }
+      if (sql.includes('FROM playlists')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
 
-  it('ignores duplicate calls (idempotent start)', () => {
-    scheduleDailyGeneration();
-    // Second call should warn but not throw
-    expect(() => scheduleDailyGeneration()).not.toThrow();
-  });
+    vi.mocked(getPool).mockReturnValue(pool as never);
+    vi.mocked(enqueueGeneration).mockResolvedValue('job-1');
 
-  it('respects DAILY_GENERATION_HOUR env var', () => {
-    process.env.DAILY_GENERATION_HOUR = '5';
-    expect(() => scheduleDailyGeneration()).not.toThrow();
-  });
-
-  it('respects DAILY_PROGRAM_CRON env var override', () => {
-    process.env.DAILY_PROGRAM_CRON = '30 3 * * *';
-    expect(() => scheduleDailyGeneration()).not.toThrow();
-  });
-
-  it('throws on an invalid DAILY_PROGRAM_CRON expression', () => {
-    process.env.DAILY_PROGRAM_CRON = 'not-a-cron';
-    expect(() => scheduleDailyGeneration()).toThrow(/Invalid cron expression/);
-  });
-
-  it('stopDailyGeneration is safe to call when not started', () => {
-    expect(() => stopDailyGeneration()).not.toThrow();
+    const result = await runDailyProgramGenerationForDate('2026-05-01');
+    expect(result.date).toBe('2026-05-01');
+    expect(result.queued).toBe(1);
+    expect(result.skipped).toBe(0);
   });
 });

--- a/services/scheduler/tests/unit/dailyProgramJob.test.ts
+++ b/services/scheduler/tests/unit/dailyProgramJob.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for dailyProgramJob.ts
+ *
+ * The job depends on a PostgreSQL pool (via getPool) and enqueueGeneration.
+ * Both are mocked here so the logic can be exercised without a real database
+ * or Redis connection.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock the db module before importing the job so getPool returns our stub.
+vi.mock('../../src/db', () => ({
+  getPool: vi.fn(),
+}));
+
+// Mock enqueueGeneration so we don't need a real Redis / BullMQ connection.
+vi.mock('../../src/services/queueService', () => ({
+  enqueueGeneration: vi.fn(),
+}));
+
+import { getPool } from '../../src/db';
+import { enqueueGeneration } from '../../src/services/queueService';
+import { runDailyProgramGeneration, scheduleDailyGeneration, stopDailyGeneration } from '../../src/jobs/dailyProgramJob';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal pg Pool mock with a controllable query function. */
+function makePoolMock(queryImpl: (sql: string, params?: unknown[]) => { rows: unknown[] }) {
+  return { query: vi.fn(queryImpl) };
+}
+
+/**
+ * Return tomorrow's date string (YYYY-MM-DD) using the same logic as the job,
+ * so test assertions stay in sync regardless of when they run.
+ */
+function tomorrowDateString(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('runDailyProgramGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues one job per active program with no existing playlists', async () => {
+    const targetDate = tomorrowDateString();
+
+    const pool = makePoolMock((sql) => {
+      // First query: programs
+      if (sql.includes('FROM programs')) {
+        return {
+          rows: [
+            { id: 'prog-1', station_id: 'station-a', template_id: 'tpl-1' },
+            { id: 'prog-2', station_id: 'station-b', template_id: null },
+          ],
+        };
+      }
+      // Second query: existing playlists — none
+      if (sql.includes('FROM playlists')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+    vi.mocked(enqueueGeneration).mockResolvedValue('job-id-1');
+
+    await runDailyProgramGeneration();
+
+    expect(enqueueGeneration).toHaveBeenCalledTimes(2);
+    expect(enqueueGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stationId: 'station-a',
+        date: targetDate,
+        templateId: 'tpl-1',
+        triggeredBy: 'cron',
+      }),
+    );
+    expect(enqueueGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stationId: 'station-b',
+        date: targetDate,
+        templateId: undefined,
+        triggeredBy: 'cron',
+      }),
+    );
+  });
+
+  it('skips stations that already have a non-failed playlist', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        return {
+          rows: [{ id: 'prog-1', station_id: 'station-a', template_id: null }],
+        };
+      }
+      if (sql.includes('FROM playlists')) {
+        // station-a already has an approved playlist
+        return { rows: [{ station_id: 'station-a', status: 'approved' }] };
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+
+    await runDailyProgramGeneration();
+
+    expect(enqueueGeneration).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue twice for the same station when multiple programs share it', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        // Two programs on the same station
+        return {
+          rows: [
+            { id: 'prog-1', station_id: 'station-x', template_id: 'tpl-1' },
+            { id: 'prog-2', station_id: 'station-x', template_id: 'tpl-2' },
+          ],
+        };
+      }
+      if (sql.includes('FROM playlists')) {
+        return { rows: [] }; // no existing playlists
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+    vi.mocked(enqueueGeneration).mockResolvedValue('job-id-x');
+
+    await runDailyProgramGeneration();
+
+    // Only the first program should result in an enqueue; the second is skipped
+    // because the station was added to skipSet after the first enqueue.
+    expect(enqueueGeneration).toHaveBeenCalledTimes(1);
+    expect(enqueueGeneration).toHaveBeenCalledWith(
+      expect.objectContaining({ stationId: 'station-x', templateId: 'tpl-1' }),
+    );
+  });
+
+  it('returns without enqueueing when no programs are active for tomorrow', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+
+    await runDailyProgramGeneration();
+
+    // playlists query should never be reached
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(enqueueGeneration).not.toHaveBeenCalled();
+  });
+
+  it('handles enqueueGeneration failures gracefully and continues with remaining programs', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        return {
+          rows: [
+            { id: 'prog-1', station_id: 'station-ok', template_id: null },
+            { id: 'prog-2', station_id: 'station-fail', template_id: null },
+          ],
+        };
+      }
+      if (sql.includes('FROM playlists')) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+    vi.mocked(enqueueGeneration)
+      .mockResolvedValueOnce('job-ok')
+      .mockRejectedValueOnce(new Error('Redis unavailable'));
+
+    // Should not throw
+    await expect(runDailyProgramGeneration()).resolves.toBeUndefined();
+    expect(enqueueGeneration).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns early when the programs query fails', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        throw new Error('DB connection error');
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+
+    await expect(runDailyProgramGeneration()).resolves.toBeUndefined();
+    expect(enqueueGeneration).not.toHaveBeenCalled();
+  });
+
+  it('returns early when the playlists idempotency query fails', async () => {
+    const pool = makePoolMock((sql) => {
+      if (sql.includes('FROM programs')) {
+        return {
+          rows: [{ id: 'prog-1', station_id: 'station-a', template_id: null }],
+        };
+      }
+      if (sql.includes('FROM playlists')) {
+        throw new Error('DB connection error');
+      }
+      return { rows: [] };
+    });
+
+    vi.mocked(getPool).mockReturnValue(pool as never);
+
+    await expect(runDailyProgramGeneration()).resolves.toBeUndefined();
+    expect(enqueueGeneration).not.toHaveBeenCalled();
+  });
+});
+
+describe('scheduleDailyGeneration / stopDailyGeneration', () => {
+  afterEach(() => {
+    // Always stop after each test to reset module-level state
+    stopDailyGeneration();
+    delete process.env.DAILY_GENERATION_HOUR;
+    delete process.env.DAILY_PROGRAM_CRON;
+  });
+
+  it('registers a cron task without throwing', () => {
+    expect(() => scheduleDailyGeneration()).not.toThrow();
+    // Confirm stop cleans up without throwing
+    expect(() => stopDailyGeneration()).not.toThrow();
+  });
+
+  it('ignores duplicate calls (idempotent start)', () => {
+    scheduleDailyGeneration();
+    // Second call should warn but not throw
+    expect(() => scheduleDailyGeneration()).not.toThrow();
+  });
+
+  it('respects DAILY_GENERATION_HOUR env var', () => {
+    process.env.DAILY_GENERATION_HOUR = '5';
+    expect(() => scheduleDailyGeneration()).not.toThrow();
+  });
+
+  it('respects DAILY_PROGRAM_CRON env var override', () => {
+    process.env.DAILY_PROGRAM_CRON = '30 3 * * *';
+    expect(() => scheduleDailyGeneration()).not.toThrow();
+  });
+
+  it('throws on an invalid DAILY_PROGRAM_CRON expression', () => {
+    process.env.DAILY_PROGRAM_CRON = 'not-a-cron';
+    expect(() => scheduleDailyGeneration()).toThrow(/Invalid cron expression/);
+  });
+
+  it('stopDailyGeneration is safe to call when not started', () => {
+    expect(() => stopDailyGeneration()).not.toThrow();
+  });
+});

--- a/services/station/src/routes/programs.ts
+++ b/services/station/src/routes/programs.ts
@@ -156,13 +156,38 @@ export async function programRoutes(app: FastifyInstance) {
     return episode;
   });
 
+  // Validate publish readiness (dry-run)
+  app.get('/program-episodes/:episodeId/publish-check', {
+    onRequest: [requirePermission('program:read')],
+  }, async (req) => {
+    const { episodeId } = req.params as { episodeId: string };
+    return programService.validatePublishReadiness(episodeId);
+  });
+
+  // Publish episode (validates, builds manifest, sets status)
   app.post('/program-episodes/:episodeId/publish', {
     onRequest: [requirePermission('program:write')],
   }, async (req, reply) => {
     const { episodeId } = req.params as { episodeId: string };
     const user = (req as unknown as { user: { sub: string } }).user;
-    const episode = await programService.publishEpisode(episodeId, user.sub);
-    if (!episode) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Episode not found' } });
-    return episode;
+    const body = req.body as { force?: boolean } | undefined;
+
+    const result = await programService.publishEpisode(episodeId, user.sub, { force: body?.force });
+
+    if (!result.episode && !result.validation.ready) {
+      return reply.code(422).send({
+        error: { code: 'NOT_READY', message: 'Episode is not ready for publishing' },
+        validation: result.validation,
+      });
+    }
+    if (!result.episode) {
+      return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Episode not found' } });
+    }
+
+    return {
+      episode: result.episode,
+      validation: result.validation,
+      manifest_url: result.manifest_url,
+    };
   });
 }

--- a/services/station/src/services/manifestBridge.ts
+++ b/services/station/src/services/manifestBridge.ts
@@ -1,0 +1,52 @@
+/**
+ * Bridge to the DJ service's manifest builder.
+ *
+ * In production, this would call the DJ service via internal HTTP.
+ * For local development (monorepo), we import directly since both
+ * services share the same database.
+ */
+
+import { getPool } from '../db';
+
+export interface ManifestResult {
+  manifest_url: string | null;
+  total_duration_sec: number;
+}
+
+/**
+ * Build a program manifest for an episode by calling the DJ service.
+ * Falls back to a direct DB query if the HTTP call fails.
+ */
+export async function buildProgramManifest(episodeId: string): Promise<ManifestResult | null> {
+  const djServiceUrl = process.env.DJ_SERVICE_INTERNAL_URL || 'http://localhost:3008';
+
+  try {
+    const response = await fetch(`${djServiceUrl}/internal/manifests/build`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ episode_id: episodeId }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (response.ok) {
+      return await response.json() as ManifestResult;
+    }
+
+    // If DJ service is not available, check if manifest already exists
+    return await getExistingManifest(episodeId);
+  } catch {
+    // DJ service unreachable — check for existing manifest
+    return await getExistingManifest(episodeId);
+  }
+}
+
+async function getExistingManifest(episodeId: string): Promise<ManifestResult | null> {
+  const { rows: [row] } = await getPool().query(
+    `SELECT m.manifest_url, m.total_duration_sec
+     FROM program_episodes pe
+     JOIN dj_show_manifests m ON m.id = pe.manifest_id
+     WHERE pe.id = $1`,
+    [episodeId],
+  );
+  return row ? { manifest_url: row.manifest_url, total_duration_sec: parseFloat(row.total_duration_sec) } : null;
+}

--- a/services/station/src/services/programService.ts
+++ b/services/station/src/services/programService.ts
@@ -263,13 +263,114 @@ export async function updateEpisode(
   return rows[0] ?? null;
 }
 
-export async function publishEpisode(id: string, userId: string): Promise<ProgramEpisode | null> {
+export interface PublishValidation {
+  ready: boolean;
+  blockers: string[];
+  warnings: string[];
+}
+
+/** Validate whether an episode is ready for publishing. */
+export async function validatePublishReadiness(id: string): Promise<PublishValidation> {
+  const pool = getPool();
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+
+  const { rows: [episode] } = await pool.query(
+    `SELECT pe.*, p.name AS program_name
+     FROM program_episodes pe
+     JOIN programs p ON p.id = pe.program_id
+     WHERE pe.id = $1`,
+    [id],
+  );
+  if (!episode) return { ready: false, blockers: ['Episode not found'], warnings: [] };
+
+  // Check playlist exists
+  if (!episode.playlist_id) {
+    blockers.push('No playlist linked to this episode');
+  } else {
+    // Check playlist status
+    const { rows: [playlist] } = await pool.query(
+      `SELECT status FROM playlists WHERE id = $1`,
+      [episode.playlist_id],
+    );
+    if (!playlist) {
+      blockers.push('Linked playlist not found');
+    } else if (playlist.status !== 'approved' && playlist.status !== 'ready') {
+      blockers.push(`Playlist status is "${playlist.status}" — must be approved or ready`);
+    }
+
+    // Check songs have audio
+    const { rows: [audioCheck] } = await pool.query(
+      `SELECT COUNT(*) AS total,
+              COUNT(s.audio_url) AS with_audio
+       FROM playlist_entries pe
+       JOIN songs s ON s.id = pe.song_id
+       WHERE pe.playlist_id = $1`,
+      [episode.playlist_id],
+    );
+    const missing = parseInt(audioCheck.total) - parseInt(audioCheck.with_audio);
+    if (missing > 0) {
+      blockers.push(`${missing} song(s) missing audio files`);
+    }
+  }
+
+  // Check DJ script
+  if (!episode.dj_script_id) {
+    warnings.push('No DJ script linked — episode will publish without DJ segments');
+  } else {
+    const { rows: [script] } = await pool.query(
+      `SELECT review_status FROM dj_scripts WHERE id = $1`,
+      [episode.dj_script_id],
+    );
+    if (script && script.review_status !== 'approved' && script.review_status !== 'auto_approved') {
+      blockers.push(`DJ script review status is "${script.review_status}" — must be approved`);
+    }
+  }
+
+  return { ready: blockers.length === 0, blockers, warnings };
+}
+
+/**
+ * Enhanced publish: validates readiness, builds manifest, sets published status.
+ * Returns the episode + validation result + manifest URL.
+ */
+export async function publishEpisode(
+  id: string,
+  userId: string,
+  opts: { force?: boolean } = {},
+): Promise<{ episode: ProgramEpisode | null; validation: PublishValidation; manifest_url?: string }> {
+  const validation = await validatePublishReadiness(id);
+
+  if (!validation.ready && !opts.force) {
+    return { episode: null, validation };
+  }
+
+  // Build manifest if DJ script exists
+  let manifestUrl: string | undefined;
+  const { rows: [ep] } = await getPool().query(
+    `SELECT dj_script_id FROM program_episodes WHERE id = $1`,
+    [id],
+  );
+  if (ep?.dj_script_id) {
+    try {
+      // Dynamic import to avoid circular dependency with dj-service
+      // In production, this calls the DJ service via HTTP; for now we build inline
+      const { buildProgramManifest } = await import('./manifestBridge');
+      const manifest = await buildProgramManifest(id);
+      manifestUrl = manifest?.manifest_url ?? undefined;
+    } catch (err) {
+      validation.warnings.push(`Manifest build failed: ${(err as Error).message}`);
+    }
+  }
+
+  // Update episode
   const { rows } = await getPool().query<ProgramEpisode>(
     `UPDATE program_episodes
-     SET published_at = NOW(), published_by = $2, updated_at = NOW()
+     SET published_at = NOW(), published_by = $2, status = 'aired', updated_at = NOW()
      WHERE id = $1
      RETURNING *`,
-    [id, userId]
+    [id, userId],
   );
-  return rows[0] ?? null;
+
+  return { episode: rows[0] ?? null, validation, manifest_url: manifestUrl };
 }

--- a/shared/db/package.json
+++ b/shared/db/package.json
@@ -8,7 +8,8 @@
     "typecheck": "tsc --noEmit",
     "migrate": "node dist/migrate.js",
     "seed": "node dist/seeds/index.js",
-    "seed:playgen": "node dist/seeds/playgen.js"
+    "seed:playgen": "node dist/seeds/playgen.js",
+    "seed:dj-personas": "node dist/seeds/dj-personas.js"
   },
   "dependencies": {
     "pg": "^8.11.0",

--- a/shared/db/src/migrations/057_add_audio_to_songs.sql
+++ b/shared/db/src/migrations/057_add_audio_to_songs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE songs ADD COLUMN audio_url TEXT;
+ALTER TABLE songs ADD COLUMN audio_source VARCHAR(50);
+COMMENT ON COLUMN songs.audio_url IS 'URL or local path to the audio file';
+COMMENT ON COLUMN songs.audio_source IS 'Provenance: upload, youtube, royalty_free';

--- a/shared/db/src/seeds/dj-personas.ts
+++ b/shared/db/src/seeds/dj-personas.ts
@@ -1,0 +1,245 @@
+/**
+ * Seed script: Creates 4 classic FM radio DJ personas for OwnRadio's full-day program
+ * and assigns each to their daypart.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... node dist/seeds/dj-personas.js
+ *
+ * Idempotent — safe to run multiple times. Uses ON CONFLICT to skip existing rows.
+ * Targets the first company and station found in the database.
+ */
+
+import { getPool } from '../client';
+
+async function seed() {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    // Guard: dj_profiles table must exist
+    const tableCheck = await client.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_name = 'dj_profiles'`,
+    );
+    if (!tableCheck.rowCount) {
+      console.warn('[seed] dj_profiles table not found — run migrations first.');
+      return;
+    }
+
+    // Resolve first company and station dynamically
+    const { rows: companyRows } = await client.query<{ id: string }>(
+      'SELECT id FROM companies LIMIT 1',
+    );
+    const { rows: stationRows } = await client.query<{ id: string }>(
+      'SELECT id FROM stations LIMIT 1',
+    );
+
+    if (!companyRows[0] || !stationRows[0]) {
+      console.error('[seed] No company or station found — seed admin first.');
+      return;
+    }
+
+    const companyId = companyRows[0].id;
+    const stationId = stationRows[0].id;
+
+    // ── DJ Profiles ──────────────────────────────────────────────────────────
+    const profiles: Array<{
+      name: string;
+      personality: string;
+      voice_style: string;
+      llm_temperature: number;
+      tts_voice_id: string;
+      persona_config: object;
+    }> = [
+      {
+        name: 'DJ Mike',
+        personality:
+          'High-energy morning host who thrives on getting people pumped for the day. ' +
+          'News-savvy, loves coffee references, quick-witted.',
+        voice_style: 'energetic',
+        llm_temperature: 0.85,
+        tts_voice_id: 'echo',
+        persona_config: {
+          backstory:
+            'Former college radio DJ who turned his passion into a career. Known for his ' +
+            'infectious energy and ability to make even Monday mornings feel exciting.',
+          energy_level: 9,
+          humor_level: 7,
+          formality: 'casual',
+          catchphrases: [
+            'Rise and grind!',
+            "Let's get this morning started!",
+            "Coffee's hot, music's hotter!",
+          ],
+          signature_greeting: 'Good morning, OwnRadio fam! DJ Mike in the house!',
+          signature_signoff:
+            "That's your morning wrapped — DJ Mike signing off. Stay awesome!",
+          topics_to_avoid: ['politics', 'religion'],
+          joke_style: 'dad',
+        },
+      },
+      {
+        name: 'DJ Luna',
+        personality:
+          'Warm, conversational midday companion. Music encyclopedia who loves sharing ' +
+          'artist stories and fun facts. Calming presence.',
+        voice_style: 'warm',
+        llm_temperature: 0.75,
+        tts_voice_id: 'nova',
+        persona_config: {
+          backstory:
+            'Music journalist turned DJ who brings deep artist knowledge and a soothing midday ' +
+            "presence. Listeners feel like they're chatting with a friend.",
+          energy_level: 5,
+          humor_level: 5,
+          formality: 'balanced',
+          catchphrases: [
+            "Here's a fun fact for you...",
+            'Music is medicine, friends',
+            'Let the music do the talking',
+          ],
+          signature_greeting: "Hey there, it's Luna keeping you company through the midday",
+          signature_signoff: 'Luna here, wishing you a beautiful rest of your day. Keep listening!',
+          topics_to_avoid: ['controversy'],
+          joke_style: 'witty',
+        },
+      },
+      {
+        name: 'DJ Rex',
+        personality:
+          'Bold, fun, pop-culture obsessed afternoon driver. Gets people hyped for the evening. ' +
+          'Loves countdowns and listener interaction.',
+        voice_style: 'bold',
+        llm_temperature: 0.9,
+        tts_voice_id: 'onyx',
+        persona_config: {
+          backstory:
+            'Former club DJ who brings that weekend energy to every weekday afternoon. Known for ' +
+            'his legendary countdown segments and surprise drops.',
+          energy_level: 8,
+          humor_level: 8,
+          formality: 'casual',
+          catchphrases: ["Let's turn it UP!", 'Drive time, baby!', "Who's ready to roll?"],
+          signature_greeting:
+            "What's good, OwnRadio! DJ Rex coming at you LIVE for the afternoon drive!",
+          signature_signoff:
+            "DJ Rex out! Don't forget — the party doesn't stop on OwnRadio!",
+          topics_to_avoid: ['politics'],
+          joke_style: 'sarcastic',
+        },
+      },
+      {
+        name: 'DJ Nyx',
+        personality:
+          'Chill, smooth late-night host. Introspective and mellow. Creates an intimate ' +
+          'listening experience with thoughtful song selections.',
+        voice_style: 'smooth',
+        llm_temperature: 0.7,
+        tts_voice_id: 'alloy',
+        persona_config: {
+          backstory:
+            'Night owl poet and vinyl collector. Creates intimate late-night vibes where every ' +
+            'song feels like it was picked just for you.',
+          energy_level: 3,
+          humor_level: 4,
+          formality: 'balanced',
+          catchphrases: ['Settle in...', "This next one's special", 'The night is young'],
+          signature_greeting:
+            'Good evening, night owls. DJ Nyx here, your companion through the night',
+          signature_signoff: 'This is Nyx, signing off into the night. Sweet dreams, OwnRadio.',
+          topics_to_avoid: ['loud', 'controversy'],
+          joke_style: 'observational',
+        },
+      },
+    ];
+
+    // Upsert each profile — conflict on (company_id, name) would be ideal but the schema
+    // only has a unique index on (company_id) WHERE is_default = TRUE.
+    // We use name + company_id existence check for idempotency instead.
+    const profileIds: Record<string, string> = {};
+
+    for (const p of profiles) {
+      const existing = await client.query<{ id: string }>(
+        'SELECT id FROM dj_profiles WHERE company_id = $1 AND name = $2',
+        [companyId, p.name],
+      );
+
+      if (existing.rowCount && existing.rowCount > 0) {
+        profileIds[p.name] = existing.rows[0].id;
+        console.log(`[seed] DJ profile "${p.name}" already exists, skipping.`);
+        continue;
+      }
+
+      const { rows: inserted } = await client.query<{ id: string }>(
+        `INSERT INTO dj_profiles (
+          company_id, name, personality, voice_style,
+          llm_model, llm_temperature,
+          tts_provider, tts_voice_id,
+          persona_config, is_default, is_active
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+        RETURNING id`,
+        [
+          companyId,
+          p.name,
+          p.personality,
+          p.voice_style,
+          'anthropic/claude-sonnet-4-5',
+          p.llm_temperature,
+          'openai',
+          p.tts_voice_id,
+          JSON.stringify(p.persona_config),
+          false,
+          true,
+        ],
+      );
+
+      profileIds[p.name] = inserted[0].id;
+      console.log(`[seed] DJ profile "${p.name}" created (id: ${inserted[0].id}).`);
+    }
+
+    // ── Daypart Assignments ───────────────────────────────────────────────────
+    const daypartAssignments: Array<{
+      dj: string;
+      daypart: 'morning' | 'midday' | 'afternoon' | 'evening';
+      start_hour: number;
+      end_hour: number;
+    }> = [
+      { dj: 'DJ Mike', daypart: 'morning',   start_hour: 6,  end_hour: 10 },
+      { dj: 'DJ Luna', daypart: 'midday',    start_hour: 10, end_hour: 14 },
+      { dj: 'DJ Rex',  daypart: 'afternoon', start_hour: 14, end_hour: 18 },
+      { dj: 'DJ Nyx',  daypart: 'evening',   start_hour: 18, end_hour: 23 },
+    ];
+
+    for (const a of daypartAssignments) {
+      const djId = profileIds[a.dj];
+      if (!djId) {
+        console.warn(`[seed] No profile ID found for "${a.dj}", skipping daypart assignment.`);
+        continue;
+      }
+
+      await client.query(
+        `INSERT INTO dj_daypart_assignments
+           (station_id, dj_profile_id, daypart, start_hour, end_hour)
+         VALUES ($1,$2,$3,$4,$5)
+         ON CONFLICT (station_id, daypart) DO UPDATE
+           SET dj_profile_id = EXCLUDED.dj_profile_id,
+               start_hour    = EXCLUDED.start_hour,
+               end_hour      = EXCLUDED.end_hour`,
+        [stationId, djId, a.daypart, a.start_hour, a.end_hour],
+      );
+
+      console.log(
+        `[seed] Daypart "${a.daypart}" assigned to "${a.dj}" ` +
+        `(${a.start_hour}:00–${a.end_hour}:00).`,
+      );
+    }
+
+    console.log('[seed] DJ personas seeded successfully.');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+seed().catch(err => {
+  console.error('[seed] Failed:', err);
+  process.exit(1);
+});

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -278,6 +278,8 @@ export interface Song {
   duration_sec: number | null;
   is_active: boolean;
   raw_material: string | null;
+  audio_url: string | null;
+  audio_source: string | null;
   created_at: Date;
   updated_at: Date;
 }

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -25,10 +25,10 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 
 ## Active Work
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
-- [ ] feat(scheduler): dailyProgramJob — program-aware cron for tomorrow's playlists (feat/daily-program-job) | @claude-sonnet-4-6 | 2026-04-22
-- [ ] feat(station): Program Import/Export — .playgen ZIP bundle export/import (feat/program-import-export) | @claude-sonnet-4-6 | 2026-04-22
+- [x] feat(station): Program Import/Export — .playgen ZIP bundle export/import (feat/program-import-export, PR #408) | @claude-sonnet-4-6 | 2026-04-22
 
 ## Recently Completed
+- [x] feat(scheduler): dailyProgramJob — program-aware cron for tomorrow's playlists (feat/daily-program-job, PR #407) | @claude-sonnet-4-6 | 2026-04-22
 - [x] feat(db+types): add audio_url/audio_source columns to songs | @claude-sonnet-4-6 | 2026-04-22 | Migration: 057
 - [x] feat(station+frontend): DJ profile on Today's Now Playing card (#299, PR #351) | @claude-code | 2026-04-13 | Migration: 056
 - [x] fix(frontend): Docker server.js standalone layout fix + docs (#246, PR #341) | @claude-code | 2026-04-09

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -25,8 +25,11 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 
 ## Active Work
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
+- [ ] feat(scheduler): dailyProgramJob — program-aware cron for tomorrow's playlists (feat/daily-program-job) | @claude-sonnet-4-6 | 2026-04-22
+- [ ] feat(station): Program Import/Export — .playgen ZIP bundle export/import (feat/program-import-export) | @claude-sonnet-4-6 | 2026-04-22
 
 ## Recently Completed
+- [x] feat(db+types): add audio_url/audio_source columns to songs | @claude-sonnet-4-6 | 2026-04-22 | Migration: 057
 - [x] feat(station+frontend): DJ profile on Today's Now Playing card (#299, PR #351) | @claude-code | 2026-04-13 | Migration: 056
 - [x] fix(frontend): Docker server.js standalone layout fix + docs (#246, PR #341) | @claude-code | 2026-04-09
 - [x] fix(auth): lazy-init Resend — no crash on missing RESEND_API_KEY (#245, PR #340) | @claude-code | 2026-04-09


### PR DESCRIPTION
## Summary
- **Migration 057**: `audio_url` + `audio_source` columns on songs table
- **Song audio sourcing**: yt-dlp download, file upload, directory bulk-import endpoints
- **DJ personas seed**: 4 classic FM radio personas (Mike/morning, Luna/midday, Rex/afternoon, Nyx/evening) with full persona_config
- **Enhanced manifest builder**: `buildProgramManifest()` — sequences songs + DJ segments with timecodes
- **Enhanced publish**: validates readiness (audio files, script approval), builds manifest, returns blockers
- **Playout engine**: HLS streaming via ffmpeg, playoutScheduler, Icecast-compatible metadata API
- **Daily program trigger**: `POST /daily-program/generate` replaces cron — on-demand generation
- **OwnRadio integration**: HLS stream + metadata endpoint consumable by OwnRadio frontend

## Test plan
- [x] Typecheck — all services pass
- [x] Lint — 0 errors, 0 warnings
- [x] Unit tests — 105 passing (auth 25, scheduler 36, station 44)
- [x] Local end-to-end: generated 156-song playlist, 22 DJ segments, published episode, served HLS stream, played in OwnRadio frontend via Chrome
- [ ] Run migration 057 on production DB
- [ ] Seed DJ personas on production
- [ ] Verify daily program trigger endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)