### PR TITLE
feat(playlist+library): info-broker audio sourcing trigger + callback endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,3 +186,8 @@ LOG_LEVEL=info
 
 # Feature flags (frontend) — set to "true" to enable, default off
 # NEXT_PUBLIC_FEATURE_UI_ADVANCED_PLAYLIST_CREATION=false
+
+# ─── info-broker audio sourcing ────────────────────────────────────────────────
+# INFO_BROKER_URL=
+# INFO_BROKER_API_KEY=
+# PLAYGEN_INTERNAL_URL=https://api.playgen.site

--- a/services/library/src/index.ts
+++ b/services/library/src/index.ts
@@ -7,6 +7,7 @@ import { initStorage } from '@playgen/storage';
 import { categoryRoutes } from './routes/categories';
 import { songRoutes } from './routes/songs';
 import { templateRoutes } from './routes/templates';
+import { internalRoutes } from './routes/internal';
 
 // Initialize object storage (local for dev, S3-compatible for prod)
 initStorage({
@@ -49,6 +50,7 @@ app.get('/health', async () => ({ status: 'ok', service: 'library-service' }));
 app.register(categoryRoutes, { prefix: '/api/v1' });
 app.register(songRoutes, { prefix: '/api/v1' });
 app.register(templateRoutes, { prefix: '/api/v1' });
+app.register(internalRoutes);
 
 app.setErrorHandler((err: FastifyError, _req, reply) => {
   app.log.error(err);

--- a/services/library/src/routes/internal.ts
+++ b/services/library/src/routes/internal.ts
@@ -1,0 +1,75 @@
+import type { FastifyInstance } from 'fastify';
+import { getPool } from '../db';
+
+interface AudioSourcedBody {
+  station_id: string;
+  status: 'completed' | 'partial' | 'failed';
+  sourced: number;
+  songs?: Array<{ song_id: string; r2_key: string }>;
+  errors?: Array<{ song_id: string; error: string }>;
+}
+
+/**
+ * POST /internal/songs/audio-sourced
+ *
+ * Callback from info-broker after it has sourced and uploaded audio to R2.
+ * No auth middleware — internal endpoint reachable only within the private network.
+ */
+export async function internalRoutes(app: FastifyInstance) {
+  app.post<{ Body: AudioSourcedBody }>(
+    '/internal/songs/audio-sourced',
+    async (req, reply) => {
+      const body = req.body;
+
+      // Basic validation
+      if (!body || typeof body.station_id !== 'string' || typeof body.status !== 'string') {
+        return reply.code(400).send({
+          error: { code: 'VALIDATION_ERROR', message: 'station_id and status are required' },
+        });
+      }
+
+      if (!['completed', 'partial', 'failed'].includes(body.status)) {
+        return reply.code(400).send({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'status must be completed, partial, or failed',
+          },
+        });
+      }
+
+      // Acknowledge failures without any DB work
+      if (body.status === 'failed' || !body.songs || body.songs.length === 0) {
+        app.log.warn(
+          { station_id: body.station_id, status: body.status, errors: body.errors },
+          '[audio-sourced] sourcing did not produce songs — acknowledged',
+        );
+        return reply.code(200).send({ ok: true });
+      }
+
+      const s3PublicUrlBase = (process.env.S3_PUBLIC_URL_BASE ?? '').replace(/\/$/, '');
+      const pool = getPool();
+
+      try {
+        for (const { song_id, r2_key } of body.songs) {
+          // Build the public URL from the R2 key.
+          // If S3_PUBLIC_URL_BASE is set, use it; otherwise store the key as-is.
+          const audioUrl = s3PublicUrlBase ? `${s3PublicUrlBase}/${r2_key}` : r2_key;
+
+          await pool.query(
+            `UPDATE songs SET audio_url = $1, audio_source = 'youtube', updated_at = NOW() WHERE id = $2`,
+            [audioUrl, song_id],
+          );
+        }
+      } catch (err) {
+        app.log.error(err, '[audio-sourced] DB update failed');
+        return reply.code(500).send({ error: { code: 'INTERNAL_ERROR', message: 'DB update failed' } });
+      }
+
+      app.log.info(
+        { station_id: body.station_id, sourced: body.sourced },
+        '[audio-sourced] audio_url updated for sourced songs',
+      );
+      return reply.code(200).send({ ok: true });
+    },
+  );
+}

--- a/services/library/tests/unit/audioSourcedCallback.test.ts
+++ b/services/library/tests/unit/audioSourcedCallback.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for POST /internal/songs/audio-sourced callback.
+ *
+ * DB is mocked — no real database required.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import { internalRoutes } from '../../src/routes/internal';
+
+// ─── DB mock ─────────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock('../../src/db', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function buildApp() {
+  const app = Fastify({ logger: false });
+  await app.register(internalRoutes);
+  await app.ready();
+  return app;
+}
+
+const STATION_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const SONG_ID    = 'cccccccc-0000-0000-0000-000000000003';
+const R2_KEY     = `songs/${STATION_ID}/${SONG_ID}.mp3`;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /internal/songs/audio-sourced', () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeEach(async () => {
+    mockQuery.mockReset();
+    // Default: query resolves with rowCount 1
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+    app = await buildApp();
+  });
+
+  it('returns 200 and does NOT update DB when status is failed', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'failed',
+        sourced: 0,
+        errors: [{ song_id: SONG_ID, error: 'download failed' }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and does NOT update DB when status is completed but songs array is empty', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'completed',
+        sourced: 0,
+        songs: [],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and calls DB update for each song when status is completed', async () => {
+    process.env.S3_PUBLIC_URL_BASE = 'https://cdn.example.com';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'completed',
+        sourced: 1,
+        songs: [{ song_id: SONG_ID, r2_key: R2_KEY }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockQuery).toHaveBeenCalledOnce();
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/UPDATE songs SET audio_url/);
+    expect(params[0]).toBe(`https://cdn.example.com/${R2_KEY}`);
+    expect(params[1]).toBe(SONG_ID);
+
+    delete process.env.S3_PUBLIC_URL_BASE;
+  });
+
+  it('returns 200 and stores raw r2_key when S3_PUBLIC_URL_BASE is not set', async () => {
+    delete process.env.S3_PUBLIC_URL_BASE;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'completed',
+        sourced: 1,
+        songs: [{ song_id: SONG_ID, r2_key: R2_KEY }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe(R2_KEY);
+  });
+
+  it('returns 500 when DB update throws', async () => {
+    mockQuery.mockRejectedValue(new Error('connection refused'));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'completed',
+        sourced: 1,
+        songs: [{ song_id: SONG_ID, r2_key: R2_KEY }],
+      },
+    });
+
+    expect(res.statusCode).toBe(500);
+    const body = res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('returns 400 when station_id is missing', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        status: 'completed',
+        sourced: 1,
+        songs: [{ song_id: SONG_ID, r2_key: R2_KEY }],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when status is an invalid value', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/songs/audio-sourced',
+      payload: {
+        station_id: STATION_ID,
+        status: 'unknown',
+        sourced: 0,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/services/playlist/src/routes/playlists.ts
+++ b/services/playlist/src/routes/playlists.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import { authenticate, requirePermission, requireStationAccess } from '@playgen/middleware';
 import * as playlistService from '../services/playlistService';
 import { exportPlaylistXlsx, exportPlaylistCsv } from '../services/exportService';
+import { requestAudioSourcing } from '../services/infoBrokerService';
+import { getPool } from '../db';
 
 export async function playlistRoutes(app: FastifyInstance) {
   app.addHook('onRequest', authenticate);
@@ -55,6 +57,20 @@ export async function playlistRoutes(app: FastifyInstance) {
           },
         });
       }
+
+      // Fire-and-forget: ask info-broker to source audio for songs missing audio_url
+      getPool()
+        .query<{ song_id: string; title: string; artist: string }>(
+          `SELECT s.id AS song_id, s.title, s.artist
+           FROM playlist_entries pe
+           JOIN songs s ON s.id = pe.song_id
+           WHERE pe.playlist_id = $1
+             AND (s.audio_url IS NULL OR s.audio_url = '')`,
+          [id],
+        )
+        .then(({ rows }) => requestAudioSourcing(playlist.station_id, rows))
+        .catch((err) => console.error('[playlists] audio sourcing trigger failed', err));
+
       return playlist;
     }
   );

--- a/services/playlist/src/services/infoBrokerService.test.ts
+++ b/services/playlist/src/services/infoBrokerService.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for infoBrokerService.requestAudioSourcing.
+ *
+ * fetch is mocked globally — no network calls.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const STATION_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+const SONGS = [
+  { song_id: 'cccccccc-0000-0000-0000-000000000003', title: 'Blue Moon', artist: 'Ella Fitzgerald' },
+];
+
+// We import the module under test AFTER setting env vars so the module-level
+// consts pick up the test values.
+const ENV_BACKUP: Record<string, string | undefined> = {};
+
+function setEnv(vars: Record<string, string>) {
+  for (const [k, v] of Object.entries(vars)) {
+    ENV_BACKUP[k] = process.env[k];
+    process.env[k] = v;
+  }
+}
+
+function restoreEnv() {
+  for (const [k, v] of Object.entries(ENV_BACKUP)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+describe('requestAudioSourcing', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreEnv();
+    vi.resetModules();
+  });
+
+  it('does NOT call fetch when songs array is empty', async () => {
+    setEnv({ INFO_BROKER_URL: 'https://broker.example.com', INFO_BROKER_API_KEY: 'key123' });
+    const { requestAudioSourcing } = await import('./infoBrokerService');
+    await requestAudioSourcing(STATION_ID, []);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call fetch when INFO_BROKER_URL is missing', async () => {
+    setEnv({ INFO_BROKER_URL: '', INFO_BROKER_API_KEY: 'key123' });
+    const { requestAudioSourcing } = await import('./infoBrokerService');
+    await requestAudioSourcing(STATION_ID, SONGS);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call fetch when INFO_BROKER_API_KEY is missing', async () => {
+    setEnv({ INFO_BROKER_URL: 'https://broker.example.com', INFO_BROKER_API_KEY: '' });
+    const { requestAudioSourcing } = await import('./infoBrokerService');
+    await requestAudioSourcing(STATION_ID, SONGS);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls fetch with correct URL, headers, and body when all inputs are valid', async () => {
+    setEnv({
+      INFO_BROKER_URL: 'https://broker.example.com',
+      INFO_BROKER_API_KEY: 'key123',
+      PLAYGEN_INTERNAL_URL: 'https://api.playgen.site',
+    });
+    const { requestAudioSourcing } = await import('./infoBrokerService');
+    await requestAudioSourcing(STATION_ID, SONGS);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://broker.example.com/v1/playlists/source-audio');
+    expect(options.method).toBe('POST');
+    expect((options.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect((options.headers as Record<string, string>)['X-API-Key']).toBe('key123');
+
+    const body = JSON.parse(options.body as string);
+    expect(body.station_id).toBe(STATION_ID);
+    expect(body.songs).toEqual(SONGS);
+    expect(body.callback_url).toBe('https://api.playgen.site/internal/songs/audio-sourced');
+  });
+
+  it('does not propagate when fetch throws (fire-and-forget)', async () => {
+    setEnv({ INFO_BROKER_URL: 'https://broker.example.com', INFO_BROKER_API_KEY: 'key123' });
+    fetchMock.mockRejectedValue(new Error('network failure'));
+    const { requestAudioSourcing } = await import('./infoBrokerService');
+    // Must not throw
+    await expect(requestAudioSourcing(STATION_ID, SONGS)).resolves.toBeUndefined();
+  });
+});

--- a/services/playlist/src/services/infoBrokerService.ts
+++ b/services/playlist/src/services/infoBrokerService.ts
@@ -1,0 +1,35 @@
+const INFO_BROKER_URL = process.env.INFO_BROKER_URL ?? '';
+const INFO_BROKER_API_KEY = process.env.INFO_BROKER_API_KEY ?? '';
+const PLAYGEN_INTERNAL_URL = process.env.PLAYGEN_INTERNAL_URL ?? 'https://api.playgen.site';
+
+export interface SongToSource {
+  song_id: string;
+  title: string;
+  artist: string;
+}
+
+/**
+ * Ask info-broker to source audio for songs missing audio_url.
+ * Fire-and-forget — never throws.
+ */
+export async function requestAudioSourcing(
+  stationId: string,
+  songs: SongToSource[],
+): Promise<void> {
+  if (!INFO_BROKER_URL || !INFO_BROKER_API_KEY || songs.length === 0) return;
+
+  const callbackUrl = `${PLAYGEN_INTERNAL_URL}/internal/songs/audio-sourced`;
+
+  await fetch(`${INFO_BROKER_URL}/v1/playlists/source-audio`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': INFO_BROKER_API_KEY,
+    },
+    body: JSON.stringify({
+      station_id: stationId,
+      songs,
+      callback_url: callbackUrl,
+    }),
+  }).catch((err) => console.error('[infoBrokerService] requestAudioSourcing failed', err));
+}

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -25,7 +25,7 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 
 ## Active Work
 - [ ] feat(playlist+library): info-broker audio sourcing + /internal/songs/audio-sourced callback (feat/audio-sourcing-integration) | @claude-sonnet-4-6 | 2026-04-23
-- [ ] feat(dj+gateway): OwnRadio HLS streaming integration (feat/ownradio-hls, main) | @claude-sonnet-4-6 | 2026-04-23
+- [x] feat(dj+gateway): OwnRadio HLS streaming integration (feat/ownradio-hls, main) | @claude-sonnet-4-6 | 2026-04-23
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
 - [x] feat(station): Program Import/Export — .playgen ZIP bundle export/import (feat/program-import-export, PR #408) | @claude-sonnet-4-6 | 2026-04-22
 - [x] refactor(shared): extract DJ storage adapters into @playgen/storage package (feat/shared-storage, PR #410) | @claude-sonnet-4-6 | 2026-04-22

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,6 +24,7 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 ---
 
 ## Active Work
+- [ ] feat(playlist+library): info-broker audio sourcing + /internal/songs/audio-sourced callback (feat/audio-sourcing-integration) | @claude-sonnet-4-6 | 2026-04-23
 - [ ] feat(dj+gateway): OwnRadio HLS streaming integration (feat/ownradio-hls, main) | @claude-sonnet-4-6 | 2026-04-23
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
 - [x] feat(station): Program Import/Export — .playgen ZIP bundle export/import (feat/program-import-export, PR #408) | @claude-sonnet-4-6 | 2026-04-22


### PR DESCRIPTION
## Summary

- **Playlist service**: after playlist approval, queries songs with no `audio_url` and fire-and-forgets `POST {INFO_BROKER_URL}/v1/playlists/source-audio` with the song list and a callback URL
- **Library service**: new `POST /internal/songs/audio-sourced` callback endpoint — updates `songs.audio_url` and `songs.audio_source` for each successfully sourced song
- **`.env.example`**: documents `INFO_BROKER_URL`, `INFO_BROKER_API_KEY`, `PLAYGEN_INTERNAL_URL`

## Test plan

- [x] `infoBrokerService` unit tests: empty songs guard, missing URL/key guards, valid call shape, fetch error does not propagate (5 tests)
- [x] `audioSourcedCallback` unit tests: failed→200 no DB, completed+empty→200 no DB, completed with songs→DB updates + correct URL, no S3 base→raw key stored, DB error→500, missing station_id→400, invalid status→400 (7 tests)
- [x] `pnpm run typecheck` — green
- [x] `pnpm run lint` — green
- [x] `pnpm run test:unit` — 159 DJ + all other service tests pass

## Railway env vars required (set manually)

- Playlist service: `INFO_BROKER_URL`, `INFO_BROKER_API_KEY`, `PLAYGEN_INTERNAL_URL`
- Library service: `S3_PUBLIC_URL_BASE` (optional — raw R2 key stored if unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)