### PR TITLE
fix(dj): manifest GET broken in production + add rebuild-manifest endpoint

### DIFF
--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -145,20 +145,42 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
       const manifestRow = await manifestService.getManifestByScript(id);
       if (!manifestRow?.manifest_url) return reply.notFound('Manifest not found');
 
-      // Extract path from URL: /api/v1/dj/audio/...
-      const prefix = '/api/v1/dj/audio/';
-      if (!manifestRow.manifest_url.startsWith(prefix)) {
-        return reply.badRequest('Invalid manifest URL format');
+      // S3/R2 storage returns a full public URL — redirect the client directly.
+      // localStorage returns /api/v1/dj/audio/<path> — serve through the proxy.
+      const localPrefix = '/api/v1/dj/audio/';
+      if (!manifestRow.manifest_url.startsWith(localPrefix)) {
+        // Validate it looks like a URL before redirecting
+        try { new URL(manifestRow.manifest_url); } catch {
+          return reply.badRequest('Invalid manifest URL format');
+        }
+        return reply.redirect(manifestRow.manifest_url);
       }
 
-      const relativePath = manifestRow.manifest_url.substring(prefix.length);
+      const relativePath = manifestRow.manifest_url.substring(localPrefix.length);
       const storage = getStorageAdapter();
-      
       try {
         const buffer = await storage.read(relativePath);
         return reply.type('application/json').send(buffer);
       } catch (err) {
         return reply.notFound('Manifest file not found on storage');
+      }
+    },
+  );
+
+  // Rebuild show manifest from current segment TTS audio
+  app.post<{ Params: { id: string } }>(
+    '/dj/scripts/:id/rebuild-manifest',
+    async (req, reply) => {
+      const { id } = req.params;
+      try {
+        await manifestService.buildManifest(id);
+        const manifestRow = await manifestService.getManifestByScript(id);
+        return { manifest_url: manifestRow?.manifest_url ?? null };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Manifest build failed';
+        if (message.includes('not found')) return reply.notFound(message);
+        req.log.error({ err }, '[rebuild-manifest] failed');
+        return reply.internalServerError(message);
       }
     },
   );


### PR DESCRIPTION
## Summary

- **Bug 1**: `GET /dj/scripts/:id/manifest` always returned 400 in production. S3/R2 storage stores full public URLs in `manifest_url`, but the route only accepted the local `/api/v1/dj/audio/` prefix.
- **Bug 2**: Even extracting the path from the S3 URL and calling `storage.read()` would fail — the S3 adapter prepends its prefix again (double-prefix), causing a 404.
- **Fix**: When `manifest_url` is an absolute URL, issue a `302` redirect to it. Local storage path serves as before.
- **New endpoint**: `POST /dj/scripts/:id/rebuild-manifest` — triggers `buildManifest()` so operators can rebuild the manifest after all TTS segments are generated, without re-running full LLM generation.

## Test plan
- [ ] `pnpm --filter @playgen/dj-service build` — clean typecheck
- [ ] Local: `POST /dj/scripts/:id/rebuild-manifest` returns `{manifest_url}`
- [ ] Local: `GET /dj/scripts/:id/manifest` returns 302 to S3 URL (local env uses S3 too)
- [ ] Production: rebuild manifest for `dd5f874e`, then GET returns 302 to R2 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)