### PR TITLE
fix(dj): fix manifest read double-prefix for S3/R2 storage

### DIFF
--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -142,21 +142,21 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
     '/dj/scripts/:id/manifest',
     async (req, reply) => {
       const { id } = req.params;
-      const manifestRow = await manifestService.getManifestByScript(id);
-      if (!manifestRow?.manifest_url) return reply.notFound('Manifest not found');
 
-      // S3/R2 storage returns a full public URL — redirect the client directly.
-      // localStorage returns /api/v1/dj/audio/<path> — serve through the proxy.
-      const localPrefix = '/api/v1/dj/audio/';
-      if (!manifestRow.manifest_url.startsWith(localPrefix)) {
-        // Validate it looks like a URL before redirecting
-        try { new URL(manifestRow.manifest_url); } catch {
-          return reply.badRequest('Invalid manifest URL format');
-        }
-        return reply.redirect(manifestRow.manifest_url);
-      }
+      // Join to get company_id so we can reconstruct the storage path without
+      // double-applying the S3 prefix that getPublicUrl() already includes.
+      const { rows } = await getPool().query<{ station_id: string; company_id: string; manifest_url: string }>(
+        `SELECT m.station_id, m.manifest_url, s.company_id
+         FROM dj_show_manifests m
+         JOIN dj_scripts s ON s.id = m.script_id
+         WHERE m.script_id = $1`,
+        [id],
+      );
+      const manifest = rows[0];
+      if (!manifest?.manifest_url) return reply.notFound('Manifest not found');
 
-      const relativePath = manifestRow.manifest_url.substring(localPrefix.length);
+      // Relative path matches what buildManifest() passed to storage.write()
+      const relativePath = `${manifest.company_id}/${manifest.station_id}/${id}_manifest.json`;
       const storage = getStorageAdapter();
       try {
         const buffer = await storage.read(relativePath);


### PR DESCRIPTION
## Summary

Follow-up to #414. The redirect approach used in #414 doesn't work because the R2 bucket is private — the public URL is not externally accessible.

**Root cause:** `storage.getPublicUrl(path)` includes the S3 prefix (e.g. `dj-audio/`) in the returned URL. Extracting the path from that URL and passing it to `storage.read()` causes the prefix to be applied twice (`dj-audio/dj-audio/...`), producing a 404.

**Fix:** Join `dj_show_manifests` with `dj_scripts` to get `company_id`, then reconstruct the original relative path that `buildManifest()` passed to `storage.write()`. This is prefix-free, so `storage.read()` applies the prefix exactly once — correct behavior for both local and S3 storage.

## Test plan
- [ ] `pnpm --filter @playgen/dj-service build` — clean typecheck  
- [ ] Local: `GET /dj/scripts/:id/manifest` returns JSON directly (no redirect)
- [ ] Production: `GET /dj/scripts/dd5f874e.../manifest` returns manifest with 102 DJ segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)