### PR TITLE
fix(dj): fix 42703 error — join stations for company_id in manifest route

### DIFF
--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -146,9 +146,10 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
       // Join to get company_id so we can reconstruct the storage path without
       // double-applying the S3 prefix that getPublicUrl() already includes.
       const { rows } = await getPool().query<{ station_id: string; company_id: string; manifest_url: string }>(
-        `SELECT m.station_id, m.manifest_url, s.company_id
+        `SELECT m.station_id, m.manifest_url, st.company_id
          FROM dj_show_manifests m
          JOIN dj_scripts s ON s.id = m.script_id
+         JOIN stations st ON st.id = s.station_id
          WHERE m.script_id = $1`,
         [id],
       );


### PR DESCRIPTION
## Summary
- `GET /dj/scripts/:id/manifest` was failing with PostgreSQL error 42703 (column does not exist)
- Root cause: query selected `s.company_id` from `dj_scripts`, but that column doesn't exist there — it lives on `stations`
- Fix: add `JOIN stations st ON st.id = s.station_id` and select `st.company_id` instead

## Test plan
- [ ] Typecheck passes (verified locally)
- [ ] Pre-existing test failures are unrelated (5 failures exist on main before this change)
- [ ] `GET /dj/scripts/:id/manifest` should return manifest JSON after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)