### PR TITLE
fix(dj): include song audio_url in buildManifest items

### DIFF
--- a/services/dj/src/services/manifestService.ts
+++ b/services/dj/src/services/manifestService.ts
@@ -61,7 +61,7 @@ export async function buildManifest(scriptId: string): Promise<string> {
 
   // 2. Get playlist entries
   const { rows: entries } = await pool.query(
-    `SELECT pe.id, pe.hour, pe.position, s.title, s.artist, s.duration_sec
+    `SELECT pe.id, pe.hour, pe.position, s.title, s.artist, s.duration_sec, s.audio_url
      FROM playlist_entries pe
      JOIN songs s ON s.id = pe.song_id
      WHERE pe.playlist_id = $1
@@ -110,6 +110,7 @@ export async function buildManifest(scriptId: string): Promise<string> {
       position: entry.position,
       title: entry.title,
       artist: entry.artist,
+      ...(entry.audio_url ? { file_path: entry.audio_url } : {}),
       duration_ms: songDurationMs,
       cumulative_ms: cumulativeMs,
     });


### PR DESCRIPTION
## Summary
- `buildManifest` query selected `pe, s.title, s.artist, s.duration_sec` but omitted `s.audio_url`
- Songs were never given a `file_path` in the manifest even after audio sourcing completed
- `buildProgramManifest` correctly selected `s.audio_url` — this fix brings the simpler function in line

## Test plan
- [ ] After rebuild-manifest, songs with `audio_url` set in DB now appear with `file_path` in manifest items

🤖 Generated with [Claude Code](https://claude.com/claude-code)