### PR TITLE
fix(dj): fix HLS playout pipeline for CDN URLs and add script-based trigger

### DIFF
--- a/services/dj/src/playout/hlsGenerator.ts
+++ b/services/dj/src/playout/hlsGenerator.ts
@@ -116,17 +116,29 @@ async function resolveAudioPath(
   audioUrl: string,
   storage: ReturnType<typeof getStorageAdapter>,
 ): Promise<string | null> {
-  // If it's already an absolute path
+  // If it's already an absolute path on disk
   if (path.isAbsolute(audioUrl) && fs.existsSync(audioUrl)) {
     return audioUrl;
   }
 
-  // Try as a storage-relative path
+  const cacheKey = audioUrl.replace(/[/\\:?=&]/g, '_').replace(/^https?__/, '');
+  const tmpPath = path.join(HLS_OUTPUT_DIR, '.cache', cacheKey);
+  fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
+
+  // If already cached locally, reuse it
+  if (fs.existsSync(tmpPath)) return tmpPath;
+
   try {
-    const buffer = await storage.read(audioUrl);
-    // Write to a temp location for ffmpeg access
-    const tmpPath = path.join(HLS_OUTPUT_DIR, '.cache', audioUrl.replace(/[/\\]/g, '_'));
-    fs.mkdirSync(path.dirname(tmpPath), { recursive: true });
+    let buffer: Buffer;
+    if (audioUrl.startsWith('http')) {
+      // Full public URL — download via HTTP
+      const res = await fetch(audioUrl);
+      if (!res.ok) throw new Error(`HTTP ${res.status} for ${audioUrl}`);
+      buffer = Buffer.from(await res.arrayBuffer());
+    } else {
+      // Relative storage key — read via adapter
+      buffer = await storage.read(audioUrl);
+    }
     await fs.promises.writeFile(tmpPath, buffer);
     return tmpPath;
   } catch {

--- a/services/dj/src/playout/playoutScheduler.ts
+++ b/services/dj/src/playout/playoutScheduler.ts
@@ -57,10 +57,17 @@ export async function startPlayout(stationId: string): Promise<PlayoutState | nu
 
   if (!episode?.manifest_url) return null;
 
-  // Load manifest from storage
-  const storage = getStorageAdapter();
-  const manifestBuffer = await storage.read(episode.manifest_url);
-  const manifest: ProgramManifest = JSON.parse(manifestBuffer.toString());
+  // Load manifest — manifest_url may be a full public CDN URL or a relative storage key
+  let manifest: ProgramManifest;
+  if (episode.manifest_url.startsWith('http')) {
+    const res = await fetch(episode.manifest_url);
+    if (!res.ok) throw new Error(`Failed to fetch manifest: ${res.status} ${episode.manifest_url}`);
+    manifest = await res.json() as ProgramManifest;
+  } else {
+    const storage = getStorageAdapter();
+    const manifestBuffer = await storage.read(episode.manifest_url);
+    manifest = JSON.parse(manifestBuffer.toString()) as ProgramManifest;
+  }
 
   const state: PlayoutState = {
     stationId,

--- a/services/dj/src/routes/manifests.ts
+++ b/services/dj/src/routes/manifests.ts
@@ -1,6 +1,9 @@
 import type { FastifyInstance } from 'fastify';
 import { buildProgramManifest, getManifestByScript } from '../services/manifestService.js';
+import type { ProgramManifest, ShowManifest } from '../services/manifestService.js';
 import { triggerPlayout } from '../playout/playoutTrigger.js';
+import { generateHls } from '../playout/hlsGenerator.js';
+import { getPool } from '../db.js';
 
 /**
  * Internal manifest routes — not exposed through the gateway.
@@ -28,5 +31,101 @@ export async function manifestRoutes(app: FastifyInstance) {
     const manifest = await getManifestByScript(scriptId);
     if (!manifest) return reply.code(404).send({ error: 'Manifest not found' });
     return manifest;
+  });
+
+  /**
+   * Trigger HLS generation + OwnRadio webhook directly from a script's
+   * existing ShowManifest. Used for E2E benchmarking without needing a
+   * fully-linked program_episode record.
+   *
+   * POST /internal/playout/trigger-by-script
+   * Body: { script_id: string }
+   */
+  app.post('/internal/playout/trigger-by-script', async (req, reply) => {
+    const { script_id } = req.body as { script_id: string };
+    if (!script_id) return reply.code(400).send({ error: 'script_id required' });
+
+    // Load the existing ShowManifest row to get station_id and manifest_url
+    const manifestRow = await getManifestByScript(script_id);
+    if (!manifestRow) {
+      return reply.code(404).send({ error: 'No manifest found for script' });
+    }
+
+    // Fetch the ShowManifest JSON from the CDN URL
+    const res = await fetch(manifestRow.manifest_url);
+    if (!res.ok) {
+      return reply.code(502).send({ error: `Failed to fetch manifest: ${res.status}` });
+    }
+    const showManifest = await res.json() as ShowManifest;
+
+    // Convert ShowManifest → ProgramManifest for the HLS generator
+    let cumulativeSec = 0;
+    const segments: ProgramManifest['segments'] = showManifest.items.map((item, idx) => {
+      const durationSec = item.duration_ms / 1000;
+      const startSec = cumulativeSec;
+      cumulativeSec += durationSec;
+      return {
+        position: idx,
+        type: item.type,
+        start_sec: startSec,
+        duration_sec: durationSec,
+        audio_url: item.file_path ?? null,
+        metadata: {
+          title: item.title ?? item.type,
+          artist: item.artist ?? 'DJ',
+        },
+      };
+    });
+
+    const programManifest: ProgramManifest = {
+      version: 1,
+      station_id: manifestRow.station_id,
+      episode_id: script_id, // use script_id as proxy
+      air_date: new Date().toISOString().slice(0, 10),
+      total_duration_sec: cumulativeSec,
+      segments,
+    };
+
+    app.log.info({ stationId: manifestRow.station_id, segments: segments.length },
+      '[trigger-by-script] starting HLS generation');
+
+    const hls = await generateHls(manifestRow.station_id, programManifest);
+
+    app.log.info({ segments: hls.totalSegments }, '[trigger-by-script] HLS ready');
+
+    // Fire OwnRadio webhook
+    const OWNRADIO_WEBHOOK_URL = process.env.OWNRADIO_WEBHOOK_URL ?? '';
+    const PLAYGEN_WEBHOOK_SECRET = process.env.PLAYGEN_WEBHOOK_SECRET ?? '';
+    const GATEWAY_URL = process.env.GATEWAY_URL ?? 'https://api.playgen.site';
+
+    if (OWNRADIO_WEBHOOK_URL) {
+      const { rows } = await getPool().query<{ slug: string }>(
+        'SELECT slug FROM stations WHERE id = $1',
+        [manifestRow.station_id],
+      ).catch(() => ({ rows: [] as { slug: string }[] }));
+
+      const slug = rows[0]?.slug;
+      if (slug) {
+        const streamUrl = `${GATEWAY_URL}/stream/${manifestRow.station_id}/playlist.m3u8`;
+        const webhookUrl = `${OWNRADIO_WEBHOOK_URL}/webhooks/stations/${slug}/stream-control`;
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (PLAYGEN_WEBHOOK_SECRET) headers['X-PlayGen-Secret'] = PLAYGEN_WEBHOOK_SECRET;
+
+        await fetch(webhookUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ action: 'url_change', streamUrl }),
+        }).catch((err) => app.log.error({ err }, '[trigger-by-script] webhook failed'));
+
+        app.log.info({ slug, streamUrl }, '[trigger-by-script] OwnRadio notified');
+      }
+    }
+
+    return {
+      status: 'ok',
+      station_id: manifestRow.station_id,
+      total_segments: hls.totalSegments,
+      stream_url: `${GATEWAY_URL}/stream/${manifestRow.station_id}/playlist.m3u8`,
+    };
   });
 }


### PR DESCRIPTION
## Summary

- **`playoutScheduler.ts`**: `startPlayout` was calling `storage.read(manifest_url)` where `manifest_url` is a full CDN URL (`https://cdn.ownradio.net/...`). The S3 storage adapter expects a relative key, not a full URL. Fixed to use `fetch()` for http URLs.
- **`hlsGenerator.ts`**: `resolveAudioPath` had the same issue — song/segment audio URLs are full CDN URLs but were passed to `storage.read()`. Fixed to use `fetch()` for http URLs, with local file cache to avoid re-downloading on re-runs.
- **`manifests.ts`**: Added `POST /internal/playout/trigger-by-script` endpoint that bypasses the `program_episode` DB requirement. Takes a `script_id`, fetches its existing ShowManifest from CDN, converts to ProgramManifest format, runs HLS generation, and fires the OwnRadio webhook.

## Test plan

- [ ] Deploy DJ service
- [ ] `POST /internal/playout/trigger-by-script` with `script_id=dd5f874e-...` returns `{status: "ok", total_segments: N, stream_url: ...}`
- [ ] OwnRadio webhook fires with the new stream URL
- [ ] `GET /stream/{stationId}/playlist.m3u8` returns a valid M3U8

🤖 Generated with [Claude Code](https://claude.com/claude-code)