### PR TITLE
fix(dj): reject script approval when LLM has not yet generated segments (#419)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## [Unreleased]
+
+_No release notes yet. This section is populated when a release tag is created._

--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -232,6 +232,15 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
       const user_id: string = (req as any).user.sub;
 
       if (action === 'approve') {
+        // Guard: reject approval if LLM generation hasn't produced segments yet (#419)
+        const { rows: segCheck } = await getPool().query(
+          'SELECT COUNT(*) AS cnt FROM dj_segments WHERE script_id = $1',
+          [id],
+        );
+        if (parseInt(segCheck[0].cnt, 10) === 0) {
+          return reply.badRequest('Script has no segments yet — LLM generation may still be in progress');
+        }
+
         const script = await scriptService.approveScript(id, user_id, review_notes);
         if (!script) return reply.badRequest('Script not found or not in pending_review state');
         return script;
@@ -326,6 +335,16 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
       const { id } = req.params;
       const { review_notes } = req.body ?? {};
       const userId: string = (req as any).user.sub;
+
+      // Guard: reject approval if LLM generation hasn't produced segments yet (#419)
+      const { rows: segCheck } = await getPool().query(
+        'SELECT COUNT(*) AS cnt FROM dj_segments WHERE script_id = $1',
+        [id],
+      );
+      if (parseInt(segCheck[0].cnt, 10) === 0) {
+        return reply.badRequest('Script has no segments yet — LLM generation may still be in progress');
+      }
+
       const script = await scriptService.approveScript(id, userId, review_notes);
       if (!script) return reply.badRequest('Script not found or not in pending_review state');
       return script;

--- a/services/dj/tests/integration/scripts.test.ts
+++ b/services/dj/tests/integration/scripts.test.ts
@@ -28,7 +28,9 @@ vi.mock('../../src/queues/djQueue.js', () => ({
 
 const COMPANY_ID = '00000000-2222-0000-0000-000000000001';
 const STATION_ID = '00000000-3333-0000-0000-000000000001';
+const USER_ID    = '00000000-4444-0000-0000-000000000001';
 const TOKEN = makeTestToken({
+  sub: USER_ID,
   company_id: COMPANY_ID,
   station_ids: [STATION_ID],
   role_code: 'company_admin',
@@ -46,6 +48,19 @@ async function seedFixtures(): Promise<{ playlistId: string; profileId: string }
      ON CONFLICT (id) DO NOTHING`,
     [COMPANY_ID],
   );
+
+  // Seed test user so reviewed_by FK constraint is satisfied on approve
+  const { rows: roleRows } = await pool.query<{ id: string }>(
+    `SELECT id FROM roles LIMIT 1`,
+  );
+  if (roleRows[0]) {
+    await pool.query(
+      `INSERT INTO users (id, company_id, role_id, email, display_name, password_hash)
+       VALUES ($1, $2, $3, 'script-test@playgen.local', 'Script Test User', 'x')
+       ON CONFLICT (id) DO NOTHING`,
+      [USER_ID, COMPANY_ID, roleRows[0].id],
+    );
+  }
 
   // Station with DJ enabled
   await pool.query(
@@ -89,6 +104,7 @@ async function teardownFixtures(playlistId: string): Promise<void> {
   await pool.query(`DELETE FROM playlists   WHERE id = $1`,          [playlistId]);
   await pool.query(`DELETE FROM dj_profiles WHERE company_id = $1`,  [COMPANY_ID]);
   await pool.query(`DELETE FROM stations    WHERE id = $1`,          [STATION_ID]);
+  await pool.query(`DELETE FROM users       WHERE id = $1`,          [USER_ID]);
   await pool.query(`DELETE FROM companies   WHERE id = $1`,          [COMPANY_ID]);
 }
 
@@ -173,21 +189,29 @@ describe('DJ Scripts API', () => {
     let scriptId: string;
 
     beforeAll(async () => {
-      // Insert a synthetic script directly in the DB so we can test review actions
-      // without running the full LLM generation pipeline.
+      // Insert a synthetic script with segments so approve succeeds
       const pool = getPool();
       const res = await pool.query<{ id: string }>(
         `INSERT INTO dj_scripts
            (playlist_id, station_id, dj_profile_id, review_status, llm_model, total_segments)
-         VALUES ($1, $2, $3, 'pending_review', 'anthropic/claude-haiku-3', 0)
+         VALUES ($1, $2, $3, 'pending_review', 'anthropic/claude-haiku-3', 1)
          RETURNING id`,
         [playlistId, STATION_ID, profileId],
       );
       scriptId = res.rows[0].id;
+
+      // Insert a segment so the approve guard passes
+      await pool.query(
+        `INSERT INTO dj_segments (script_id, position, segment_type, script_text)
+         VALUES ($1, 0, 'show_intro', 'Hello listeners!')`,
+        [scriptId],
+      );
     });
 
     afterAll(async () => {
-      await getPool().query(`DELETE FROM dj_scripts WHERE id = $1`, [scriptId]);
+      const pool = getPool();
+      await pool.query(`DELETE FROM dj_segments WHERE script_id = $1`, [scriptId]);
+      await pool.query(`DELETE FROM dj_scripts WHERE id = $1`, [scriptId]);
     });
 
     it('POST /api/v1/dj/scripts/:id/review returns 401 without auth', async () => {
@@ -242,6 +266,51 @@ describe('DJ Scripts API', () => {
         payload: { action: 'edit', edited_segments: [] },
       });
       expect(res.statusCode).toBe(400);
+    });
+  });
+
+  // ── Approve guard: reject when no segments exist (#419) ─────────────────────
+
+  describe('approve with zero segments guard (#419)', () => {
+    let emptyScriptId: string;
+
+    beforeAll(async () => {
+      const pool = getPool();
+      const res = await pool.query<{ id: string }>(
+        `INSERT INTO dj_scripts
+           (playlist_id, station_id, dj_profile_id, review_status, llm_model, total_segments)
+         VALUES ($1, $2, $3, 'pending_review', 'anthropic/claude-haiku-3', 0)
+         RETURNING id`,
+        [playlistId, STATION_ID, profileId],
+      );
+      emptyScriptId = res.rows[0].id;
+      // Deliberately NO segments inserted — simulates LLM still generating
+    });
+
+    afterAll(async () => {
+      await getPool().query(`DELETE FROM dj_scripts WHERE id = $1`, [emptyScriptId]);
+    });
+
+    it('POST /dj/scripts/:id/approve returns 400 when script has no segments', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/v1/dj/scripts/${emptyScriptId}/approve`,
+        headers: { authorization: AUTH_HEADER, 'content-type': 'application/json' },
+        payload: {},
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toMatch(/no segments/i);
+    });
+
+    it('POST /review with action=approve returns 400 when script has no segments', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/api/v1/dj/scripts/${emptyScriptId}/review`,
+        headers: { authorization: AUTH_HEADER, 'content-type': 'application/json' },
+        payload: { action: 'approve' },
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json().message).toMatch(/no segments/i);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added guard to `POST /dj/scripts/:id/approve` and `POST /dj/scripts/:id/review` (action=approve) that returns **400** if `dj_segments` count is 0
- Prevents silent approval leaving scripts in approved state with no audio when LLM is still generating
- Fixes pre-existing test regression: seeded valid UUID user row for `reviewed_by` FK constraint in integration tests

## Root Cause
`approveScript()` updated `review_status` without checking whether segments existed. Since TTS is triggered per-segment, approving with 0 segments meant nothing happened — no audio, no error.

## Test Plan
- [x] `POST /dj/scripts/:id/approve` returns 400 with "no segments" message when script has 0 segments
- [x] `POST /dj/scripts/:id/review` action=approve returns 400 with "no segments" message when script has 0 segments  
- [x] Normal approve still works when segments exist
- [x] `pnpm run typecheck && pnpm run lint && pnpm run test:unit` all pass

Closes #419