### PR TITLE
fix(dj): CDN-backed HLS playlist + status.json 400 fix

### DIFF
--- a/services/dj/src/playout/streamRoutes.ts
+++ b/services/dj/src/playout/streamRoutes.ts
@@ -8,6 +8,7 @@ import {
   getActivePlayouts,
 } from './playoutScheduler.js';
 import { generateHls, cleanupHls } from './hlsGenerator.js';
+import { getPool } from '../db.js';
 
 const HLS_OUTPUT_DIR = process.env.HLS_OUTPUT_PATH || path.join(process.cwd(), 'data', 'hls');
 
@@ -60,15 +61,77 @@ export async function streamRoutes(app: FastifyInstance) {
 
   // ── Public HLS streaming ────────────────────────────────────────────────────
 
-  /** Serve HLS playlist (.m3u8) for a station. */
+  /**
+   * Serve HLS playlist (.m3u8) for a station.
+   *
+   * Priority:
+   *   1. CDN-backed — dynamically built from dj_segments audio_url (R2 CDN URLs).
+   *      Durable across restarts; no local disk dependency.
+   *   2. Local fallback — reads from HLS_OUTPUT_DIR (dev / legacy playout).
+   */
   app.get('/stream/:stationId/playlist.m3u8', async (req, reply) => {
     const { stationId } = req.params as { stationId: string };
-    const playlistPath = path.join(HLS_OUTPUT_DIR, stationId, 'playlist.m3u8');
 
+    // ── 1. Try CDN-backed playlist from DB ──────────────────────────────────
+    try {
+      const pool = getPool();
+      const { rows } = await pool.query<{
+        audio_url: string;
+        audio_duration_sec: number | null;
+        position: number;
+      }>(
+        `SELECT ds.audio_url, ds.audio_duration_sec, ds.position
+         FROM dj_segments ds
+         WHERE ds.script_id = (
+           SELECT sc.id
+           FROM dj_scripts sc
+           JOIN playlists pl ON pl.id = sc.playlist_id
+           WHERE sc.station_id = $1
+             AND sc.review_status IN ('approved', 'auto_approved')
+             AND EXISTS (
+               SELECT 1 FROM dj_segments s2
+               WHERE s2.script_id = sc.id
+                 AND s2.audio_url LIKE 'http%'
+             )
+           ORDER BY pl.date DESC
+           LIMIT 1
+         )
+         AND ds.audio_url LIKE 'http%'
+         ORDER BY ds.position`,
+        [stationId],
+      );
+
+      if (rows.length > 0) {
+        const maxDuration = Math.ceil(
+          Math.max(...rows.map((r) => r.audio_duration_sec ?? 0)),
+        );
+        const lines = [
+          '#EXTM3U',
+          '#EXT-X-VERSION:3',
+          `#EXT-X-TARGETDURATION:${maxDuration || 300}`,
+          '#EXT-X-PLAYLIST-TYPE:VOD',
+        ];
+        for (const seg of rows) {
+          lines.push(`#EXTINF:${(seg.audio_duration_sec ?? 0).toFixed(3)},`);
+          lines.push(seg.audio_url);
+        }
+        lines.push('#EXT-X-ENDLIST');
+
+        return reply
+          .header('Content-Type', 'application/vnd.apple.mpegurl')
+          .header('Cache-Control', 'no-cache, no-store')
+          .header('Access-Control-Allow-Origin', '*')
+          .send(lines.join('\n'));
+      }
+    } catch (err) {
+      req.log.warn({ err }, '[stream] CDN playlist query failed, falling back to local');
+    }
+
+    // ── 2. Local fallback (dev / legacy) ────────────────────────────────────
+    const playlistPath = path.join(HLS_OUTPUT_DIR, stationId, 'playlist.m3u8');
     if (!fs.existsSync(playlistPath)) {
       return reply.code(404).send({ error: 'Stream not available' });
     }
-
     const content = await fs.promises.readFile(playlistPath, 'utf-8');
     return reply
       .header('Content-Type', 'application/vnd.apple.mpegurl')
@@ -77,12 +140,72 @@ export async function streamRoutes(app: FastifyInstance) {
       .send(content);
   });
 
-  /** Serve HLS segment (.ts) for a station. */
+  // ── Now-playing metadata API (public, for OwnRadio polling) ─────────────────
+
+  /**
+   * status.json — now-playing metadata polled by OwnRadio.
+   * Must be registered BEFORE the generic :segment handler to avoid 400.
+   */
+  app.get('/stream/:stationId/status.json', async (req, reply) => {
+    const { stationId } = req.params as { stationId: string };
+
+    // Prefer live now-playing from the in-memory scheduler
+    const nowPlaying = getNowPlaying(stationId);
+    if (nowPlaying) {
+      return reply
+        .header('Content-Type', 'application/json')
+        .header('Access-Control-Allow-Origin', '*')
+        .send({
+          title: `${nowPlaying.segment.metadata.artist} - ${nowPlaying.segment.metadata.title}`,
+          artist: nowPlaying.segment.metadata.artist,
+          song: nowPlaying.segment.metadata.title,
+          elapsed_sec: nowPlaying.elapsed_sec,
+          remaining_sec: nowPlaying.remaining_sec,
+        });
+    }
+
+    // Fallback: return the first song segment from the latest approved script in DB
+    try {
+      const pool = getPool();
+      const { rows } = await pool.query<{ song_title: string; song_artist: string }>(
+        `SELECT pe_song.title AS song_title, pe_song.artist AS song_artist
+         FROM dj_segments ds
+         JOIN dj_scripts sc ON sc.id = ds.script_id
+         JOIN playlists pl ON pl.id = sc.playlist_id
+         LEFT JOIN playlist_entries pe ON pe.id = ds.playlist_entry_id
+         LEFT JOIN songs pe_song ON pe_song.id = pe.song_id
+         WHERE sc.station_id = $1
+           AND sc.review_status IN ('approved', 'auto_approved')
+           AND ds.segment_type IN ('song_intro', 'song_transition')
+           AND pe_song.title IS NOT NULL
+         ORDER BY pl.date DESC, ds.position ASC
+         LIMIT 1`,
+        [stationId],
+      );
+
+      const track = rows[0];
+      return reply
+        .header('Content-Type', 'application/json')
+        .header('Access-Control-Allow-Origin', '*')
+        .send({
+          title: track ? `${track.song_artist} - ${track.song_title}` : 'PlayGen Radio',
+          artist: track?.song_artist ?? '',
+          song: track?.song_title ?? '',
+        });
+    } catch {
+      return reply
+        .header('Content-Type', 'application/json')
+        .header('Access-Control-Allow-Origin', '*')
+        .send({ title: 'PlayGen Radio', artist: '', song: '' });
+    }
+  });
+
+  /** Serve HLS segment (.ts) for a station (local/legacy playout only). */
   app.get('/stream/:stationId/:segment', async (req, reply) => {
     const { stationId, segment } = req.params as { stationId: string; segment: string };
 
     if (!segment.endsWith('.ts')) {
-      return reply.code(400).send({ error: 'Invalid segment' });
+      return reply.code(404).send({ error: 'Segment not found' });
     }
 
     const segmentPath = path.join(HLS_OUTPUT_DIR, stationId, segment);
@@ -98,9 +221,7 @@ export async function streamRoutes(app: FastifyInstance) {
       .send(stream);
   });
 
-  // ── Now-playing metadata API (public, for OwnRadio polling) ─────────────────
-
-  /** Get current track metadata — compatible with Icecast JSON format for OwnRadio. */
+  /** Get current track metadata — extended format. */
   app.get('/stream/:stationId/metadata', async (req, reply) => {
     const { stationId } = req.params as { stationId: string };
     const nowPlaying = getNowPlaying(stationId);
@@ -109,7 +230,6 @@ export async function streamRoutes(app: FastifyInstance) {
       return reply.code(404).send({ error: 'Station not playing' });
     }
 
-    // Return in Icecast-compatible format for OwnRadio compatibility
     return reply
       .header('Access-Control-Allow-Origin', '*')
       .send({
@@ -118,7 +238,6 @@ export async function streamRoutes(app: FastifyInstance) {
             title: `${nowPlaying.segment.metadata.artist} - ${nowPlaying.segment.metadata.title}`,
           },
         },
-        // Extended metadata for direct integration
         playgen: {
           segment: nowPlaying.segment,
           elapsed_sec: nowPlaying.elapsed_sec,

--- a/services/dj/src/routes/scripts.ts
+++ b/services/dj/src/routes/scripts.ts
@@ -190,21 +190,79 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
   );
 
   /**
-   * Trigger HLS generation + OwnRadio webhook for a script's existing ShowManifest.
-   * Returns 202 immediately; HLS generation runs in the background (may take minutes).
+   * Trigger playout for a script.
+   *
+   * CDN-backed path (preferred): if dj_segments already have R2 CDN audio_urls,
+   * the playlist is served dynamically from the DB — no ffmpeg, no ephemeral disk.
+   * Returns 200 synchronously with the stream URL and notifies OwnRadio.
+   *
+   * Legacy path: falls back to ffmpeg HLS generation from a ShowManifest.
+   * Returns 202 immediately; generation runs in the background.
    */
   app.post<{ Params: { id: string } }>(
     '/dj/scripts/:id/trigger-playout',
     async (req, reply) => {
       const { id } = req.params;
-      const manifestRow = await manifestService.getManifestByScript(id);
-      if (!manifestRow) return reply.notFound('No manifest found for this script');
-      if (!manifestRow.manifest_url) return reply.badRequest('Script has no manifest URL yet');
-
       const GATEWAY_URL = process.env.GATEWAY_URL ?? 'https://api.playgen.site';
-      const streamUrl = `${GATEWAY_URL}/stream/${manifestRow.station_id}/playlist.m3u8`;
+      const OWNRADIO_WEBHOOK_URL = process.env.OWNRADIO_WEBHOOK_URL ?? '';
+      const PLAYGEN_WEBHOOK_SECRET = process.env.PLAYGEN_WEBHOOK_SECRET ?? '';
 
-      // Fire-and-forget HLS generation + webhook
+      // ── Check for CDN-backed segments ──────────────────────────────────────
+      const { rows: cdnCheck } = await getPool().query<{
+        station_id: string;
+        cdn_count: string;
+        total_count: string;
+      }>(
+        `SELECT sc.station_id,
+                COUNT(*) FILTER (WHERE ds.audio_url LIKE 'http%') AS cdn_count,
+                COUNT(*) AS total_count
+         FROM dj_scripts sc
+         JOIN dj_segments ds ON ds.script_id = sc.id
+         WHERE sc.id = $1
+         GROUP BY sc.station_id`,
+        [id],
+      );
+
+      const row = cdnCheck[0];
+      if (!row) return reply.notFound('Script not found');
+
+      const streamUrl = `${GATEWAY_URL}/stream/${row.station_id}/playlist.m3u8`;
+      const isCdnBacked = parseInt(row.cdn_count) > 0;
+
+      if (isCdnBacked) {
+        // ── CDN path: playlist served dynamically from DB, no ffmpeg ──────
+        req.log.info(
+          { scriptId: id, stationId: row.station_id, cdnSegments: row.cdn_count },
+          '[trigger-playout] CDN-backed — serving from DB, skipping ffmpeg',
+        );
+
+        // Notify OwnRadio (fire-and-forget)
+        if (OWNRADIO_WEBHOOK_URL) {
+          const { rows: slugRows } = await getPool()
+            .query<{ slug: string }>('SELECT slug FROM stations WHERE id = $1', [row.station_id])
+            .catch(() => ({ rows: [] as { slug: string }[] }));
+          const slug = slugRows[0]?.slug;
+          if (slug) {
+            const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+            if (PLAYGEN_WEBHOOK_SECRET) headers['X-PlayGen-Secret'] = PLAYGEN_WEBHOOK_SECRET;
+            fetch(`${OWNRADIO_WEBHOOK_URL}/webhooks/stations/${slug}/stream-control`, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify({ action: 'url_change', streamUrl }),
+            }).catch((err) => req.log.error({ err }, '[trigger-playout] webhook failed'));
+            req.log.info({ slug, streamUrl }, '[trigger-playout] OwnRadio notified');
+          }
+        }
+
+        return reply.code(200).send({ status: 'ready', stream_url: streamUrl, source: 'cdn' });
+      }
+
+      // ── Legacy path: ffmpeg HLS from ShowManifest ──────────────────────────
+      const manifestRow = await manifestService.getManifestByScript(id);
+      if (!manifestRow?.manifest_url) {
+        return reply.badRequest('No CDN audio and no manifest URL — cannot trigger playout');
+      }
+
       (async () => {
         try {
           const res = await fetch(manifestRow.manifest_url);
@@ -228,24 +286,22 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
 
           const programManifest: ProgramManifest = {
             version: 1,
-            station_id: manifestRow.station_id,
+            station_id: row.station_id,
             episode_id: id,
             air_date: new Date().toISOString().slice(0, 10),
             total_duration_sec: cumulativeSec,
             segments,
           };
 
-          const hls = await generateHls(manifestRow.station_id, programManifest);
-          req.log.info({ stationId: manifestRow.station_id, segments: hls.totalSegments },
-            '[trigger-playout] HLS ready');
+          const hls = await generateHls(row.station_id, programManifest);
+          req.log.info({ stationId: row.station_id, segments: hls.totalSegments },
+            '[trigger-playout] legacy HLS ready');
 
-          const OWNRADIO_WEBHOOK_URL = process.env.OWNRADIO_WEBHOOK_URL ?? '';
-          const PLAYGEN_WEBHOOK_SECRET = process.env.PLAYGEN_WEBHOOK_SECRET ?? '';
           if (OWNRADIO_WEBHOOK_URL) {
-            const { rows } = await getPool().query<{ slug: string }>(
-              'SELECT slug FROM stations WHERE id = $1', [manifestRow.station_id],
-            ).catch(() => ({ rows: [] as { slug: string }[] }));
-            const slug = rows[0]?.slug;
+            const { rows: slugRows } = await getPool()
+              .query<{ slug: string }>('SELECT slug FROM stations WHERE id = $1', [row.station_id])
+              .catch(() => ({ rows: [] as { slug: string }[] }));
+            const slug = slugRows[0]?.slug;
             if (slug) {
               const headers: Record<string, string> = { 'Content-Type': 'application/json' };
               if (PLAYGEN_WEBHOOK_SECRET) headers['X-PlayGen-Secret'] = PLAYGEN_WEBHOOK_SECRET;
@@ -253,7 +309,6 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
                 method: 'POST', headers,
                 body: JSON.stringify({ action: 'url_change', streamUrl }),
               }).catch((err) => req.log.error({ err }, '[trigger-playout] webhook failed'));
-              req.log.info({ slug, streamUrl }, '[trigger-playout] OwnRadio notified');
             }
           }
         } catch (err) {
@@ -261,7 +316,7 @@ export async function scriptRoutes(app: FastifyInstance): Promise<void> {
         }
       })();
 
-      return reply.code(202).send({ status: 'generating', stream_url: streamUrl });
+      return reply.code(202).send({ status: 'generating', stream_url: streamUrl, source: 'ffmpeg' });
     },
   );
 


### PR DESCRIPTION
## Summary

- **CDN-backed M3U8**: `GET /stream/:stationId/playlist.m3u8` now queries `dj_segments` and serves a playlist of R2 CDN audio URLs directly — no ffmpeg, no ephemeral container disk. Falls back to local HLS files for dev/legacy.
- **`status.json` 400 fixed**: Added explicit `GET /stream/:stationId/status.json` handler before the generic `:segment` route. Returns now-playing from in-memory scheduler, or latest song from DB. Closes rinehardramos/ownradio#14.
- **`trigger-playout` CDN path**: Detects CDN-backed scripts (segments with `http` audio_url), returns `200` synchronously with stream URL and notifies OwnRadio immediately — no background ffmpeg job. Legacy ffmpeg path retained for dev.
- **`:segment` non-.ts**: Returns 404 instead of 400 for unrecognized extensions.

## Why CDN-backed M3U8

Railway filesystem is ephemeral — ffmpeg-generated `.ts` files are wiped on every deploy/restart. A dynamically-served M3U8 that references R2 CDN URLs is durable, restartable, and requires zero disk. This is a prerequisite for the Publish to Production pipeline (#436).

## Test plan

- [ ] `GET /stream/<stationId>/playlist.m3u8` returns a valid M3U8 with R2 CDN URLs when station has published segments with CDN audio_url
- [ ] Falls back to local `.m3u8` file when no CDN segments exist
- [ ] `GET /stream/<stationId>/status.json` returns 200 JSON (not 400)
- [ ] `POST /dj/scripts/<id>/trigger-playout` returns 200 synchronously for CDN-backed scripts
- [ ] OwnRadio webhook is called after CDN trigger-playout

🤖 Generated with [Claude Code](https://claude.com/claude-code)