### PR TITLE
fix(dj): parse audio_duration_sec as float in CDN HLS playlist builder

### DIFF
--- a/services/dj/src/playout/streamRoutes.ts
+++ b/services/dj/src/playout/streamRoutes.ts
@@ -103,7 +103,7 @@ export async function streamRoutes(app: FastifyInstance) {
 
       if (rows.length > 0) {
         const maxDuration = Math.ceil(
-          Math.max(...rows.map((r) => r.audio_duration_sec ?? 0)),
+          Math.max(...rows.map((r) => parseFloat(String(r.audio_duration_sec ?? 0)))),
         );
         const lines = [
           '#EXTM3U',
@@ -112,7 +112,8 @@ export async function streamRoutes(app: FastifyInstance) {
           '#EXT-X-PLAYLIST-TYPE:VOD',
         ];
         for (const seg of rows) {
-          lines.push(`#EXTINF:${(seg.audio_duration_sec ?? 0).toFixed(3)},`);
+          const dur = parseFloat(String(seg.audio_duration_sec ?? 0));
+          lines.push(`#EXTINF:${dur.toFixed(3)},`);
           lines.push(seg.audio_url);
         }
         lines.push('#EXT-X-ENDLIST');


### PR DESCRIPTION
## Root cause
`pg` returns `NUMERIC` columns as JS strings. Calling `.toFixed()` on a string throws `TypeError: (seg.audio_duration_sec ?? 0).toFixed is not a function`, causing the CDN-backed playlist builder to throw → fall back to local file → 404 "Stream not available" → OwnRadio hears nothing.

## Fix
`parseFloat(String(seg.audio_duration_sec ?? 0))` before `.toFixed(3)` and in `Math.max`.

## Test plan
- [x] `pnpm run typecheck` passes
- [ ] `curl https://api.playgen.site/stream/4cacfc33-40cf-471a-81a5-efd25f6e8f5d/playlist.m3u8` returns valid M3U8 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)