### PR TITLE
fix(dj+station): URL-encode HLS playlist URLs and fix R2 key date format

### DIFF
--- a/services/dj/src/playout/streamRoutes.ts
+++ b/services/dj/src/playout/streamRoutes.ts
@@ -114,7 +114,7 @@ export async function streamRoutes(app: FastifyInstance) {
         for (const seg of rows) {
           const dur = parseFloat(String(seg.audio_duration_sec ?? 0));
           lines.push(`#EXTINF:${dur.toFixed(3)},`);
-          lines.push(seg.audio_url);
+          lines.push(encodeURI(seg.audio_url));
         }
         lines.push('#EXT-X-ENDLIST');
 

--- a/services/station/src/queues/publishPipeline.ts
+++ b/services/station/src/queues/publishPipeline.ts
@@ -190,7 +190,8 @@ async function stageUploadAssets(scriptId: string, stationSlug: string, playlist
     // Skip segments already on CDN
     if (seg.audio_url.startsWith('http')) continue;
 
-    const s3Key = `programs/${stationSlug}/${playlistDate}/${seg.position}_${seg.segment_type}.mp3`;
+    const dateStr = new Date(playlistDate).toISOString().split('T')[0]; // YYYY-MM-DD, no spaces
+    const s3Key = `programs/${stationSlug}/${dateStr}/${seg.position}_${seg.segment_type}.mp3`;
 
     // Check if already uploaded (idempotent resume)
     try {


### PR DESCRIPTION
## Summary
- `streamRoutes.ts`: wrap `seg.audio_url` with `encodeURI()` when building the M3U8 playlist — spaces in existing R2 keys were emitted as-is, violating the HLS spec and causing OwnRadio playback to fail silently
- `publishPipeline.ts`: replace `${playlistDate}` in S3 key with `new Date(playlistDate).toISOString().split('T')[0]` — `pg` returns PostgreSQL `date` columns as JS `Date` objects; template-literal coercion calls `.toString()` producing `"Fri Apr 24 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"` with spaces

## Root cause
`node-postgres` returns `DATE` columns as JS `Date` objects. When interpolated directly into a template string, `.toString()` produces a human-readable string with spaces and parentheses, creating invalid R2 keys and consequently invalid HLS URIs.

## Test plan
- [ ] `pnpm run typecheck && pnpm run lint && pnpm run test:unit` — all pass ✓
- [ ] After deploy: `curl https://api.playgen.site/stream/4cacfc33-40cf-471a-81a5-efd25f6e8f5d/playlist.m3u8` returns M3U8 with `%20`-encoded URLs
- [ ] OwnRadio plays audio for Metro Manila Mix station

🤖 Generated with [Claude Code](https://claude.com/claude-code)