### PR TITLE
fix(dj): prune orphaned DJ speech when associated song has no CDN audio (#448-AC1)

### DIFF
--- a/services/dj/src/playout/streamRoutes.ts
+++ b/services/dj/src/playout/streamRoutes.ts
@@ -102,6 +102,19 @@ export async function streamRoutes(app: FastifyInstance) {
            FROM dj_segments ds
            JOIN latest_script ls ON ls.id = ds.script_id
            WHERE ds.audio_url LIKE 'http%'
+             AND (
+               -- Non-song segments (show_intro, show_outro, time_check, weather_tease, etc.): always include
+               ds.segment_type NOT IN ('song_intro', 'song_transition')
+               OR ds.playlist_entry_id IS NULL
+               -- Song-paired segments: only include if the associated song has CDN audio
+               OR EXISTS (
+                 SELECT 1 FROM playlist_entries pe
+                 JOIN songs s ON s.id = pe.song_id
+                 WHERE pe.id = ds.playlist_entry_id
+                   AND s.audio_url IS NOT NULL
+                   AND s.audio_url LIKE 'http%'
+               )
+             )
 
            UNION ALL
 

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,6 +24,7 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 ---
 
 ## Active Work
+- [ ] fix(dj): segment pruning — skip orphaned DJ speech when song has no audio (#448-AC1, fix/issue-448-pruning) | @claude-sonnet-4-6 | 2026-04-25
 - [ ] feat(dj+station+publish): full program audio in HLS stream — song audio in M3U8 + sourcing trigger in publish pipeline (feat/full-program-audio) | @claude-sonnet-4-6 | 2026-04-25
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
 


### PR DESCRIPTION
## Summary
- Adds a pruning filter to Branch 1 (DJ speech) of the CDN-backed M3U8 UNION query
- `song_intro` / `song_transition` segments are now excluded from the playlist when their associated song has no CDN `audio_url`, eliminating orphaned "Next up is X" speech with no song following
- Non-song segment types (`show_intro`, `show_outro`, `time_check`, `weather_tease`) are always preserved — they have no `playlist_entry_id` and must never be pruned

## Root cause
Branch 1 selected all DJ segments with a CDN `audio_url`. Branch 2 filtered song slots to only those with CDN audio. The mismatch meant a `song_intro` speech segment could appear in the M3U8 with no corresponding song segment immediately after it.

## Fix diff (Branch 1 WHERE clause)
```sql
WHERE ds.audio_url LIKE 'http%'
  AND (
    ds.segment_type NOT IN ('song_intro', 'song_transition')
    OR ds.playlist_entry_id IS NULL
    OR EXISTS (
      SELECT 1 FROM playlist_entries pe
      JOIN songs s ON s.id = pe.song_id
      WHERE pe.id = ds.playlist_entry_id
        AND s.audio_url IS NOT NULL
        AND s.audio_url LIKE 'http%'
    )
  )
```

## Test plan
- [ ] typecheck: pass
- [ ] lint: pass
- [ ] test:unit: 313 tests pass across all services (dj: 159 pass)
- [ ] CI green on push

Closes #448 (AC#1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)