### PR TITLE
fix(dj+station): scope station slug uniqueness to company_id — fixes same-stream bug (#449)

### DIFF
--- a/services/dj/tests/unit/streamRoutes.test.ts
+++ b/services/dj/tests/unit/streamRoutes.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for #449 — stationId scoping in M3U8 builder.
+ *
+ * Verifies that `GET /stream/:stationId/playlist.m3u8` passes the correct
+ * station_id as a DB query parameter for each request, so two different
+ * stations never share segments.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+
+const STATION_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+const STATION_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+const CDN_SEG_A = 'https://cdn.example.com/station-a/seg1.mp3';
+const CDN_SEG_B = 'https://cdn.example.com/station-b/seg1.mp3';
+
+describe('GET /stream/:stationId/playlist.m3u8 — stationId scoping', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('passes the correct stationId to the DB query for each station', async () => {
+    const queryCalls: Array<[string, unknown[]]> = [];
+    const mockQuery = vi.fn().mockImplementation((sql: string, params: unknown[]) => {
+      queryCalls.push([sql, params]);
+      const stationId = params[0] as string;
+      if (stationId === STATION_A) {
+        return Promise.resolve({
+          rows: [{ audio_url: CDN_SEG_A, audio_duration_sec: 30 }],
+        });
+      }
+      if (stationId === STATION_B) {
+        return Promise.resolve({
+          rows: [{ audio_url: CDN_SEG_B, audio_duration_sec: 45 }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    vi.doMock('../../src/db', () => ({
+      getPool: () => ({ query: mockQuery }),
+    }));
+    vi.doMock('../../src/playout/playoutScheduler', () => ({
+      startPlayout: vi.fn(),
+      stopPlayout: vi.fn(),
+      getNowPlaying: vi.fn().mockReturnValue(null),
+      getActivePlayouts: vi.fn().mockReturnValue([]),
+    }));
+    vi.doMock('../../src/playout/hlsGenerator', () => ({
+      generateHls: vi.fn(),
+      cleanupHls: vi.fn(),
+    }));
+
+    const { streamRoutes } = await import('../../src/playout/streamRoutes.js');
+    const app = Fastify();
+    await app.register(streamRoutes);
+    await app.ready();
+
+    // Station A request
+    const resA = await app.inject({ method: 'GET', url: `/stream/${STATION_A}/playlist.m3u8` });
+    expect(resA.statusCode).toBe(200);
+    expect(resA.body).toContain(CDN_SEG_A);
+    expect(resA.body).not.toContain(CDN_SEG_B);
+
+    // Station B request
+    const resB = await app.inject({ method: 'GET', url: `/stream/${STATION_B}/playlist.m3u8` });
+    expect(resB.statusCode).toBe(200);
+    expect(resB.body).toContain(CDN_SEG_B);
+    expect(resB.body).not.toContain(CDN_SEG_A);
+
+    // Verify DB was called with the correct stationId for each request
+    const cdnQueryCalls = queryCalls.filter(([sql]) => sql.includes('latest_script'));
+    expect(cdnQueryCalls).toHaveLength(2);
+    expect(cdnQueryCalls[0][1]).toContain(STATION_A);
+    expect(cdnQueryCalls[1][1]).toContain(STATION_B);
+
+    await app.close();
+  });
+
+  it('returns 404 when no approved CDN segments exist for a station', async () => {
+    vi.doMock('../../src/db', () => ({
+      getPool: () => ({
+        query: vi.fn().mockResolvedValue({ rows: [] }),
+      }),
+    }));
+    vi.doMock('../../src/playout/playoutScheduler', () => ({
+      startPlayout: vi.fn(),
+      stopPlayout: vi.fn(),
+      getNowPlaying: vi.fn().mockReturnValue(null),
+      getActivePlayouts: vi.fn().mockReturnValue([]),
+    }));
+    vi.doMock('../../src/playout/hlsGenerator', () => ({
+      generateHls: vi.fn(),
+      cleanupHls: vi.fn(),
+    }));
+
+    // Prevent local file check from finding a file on disk
+    vi.doMock('fs', async (importOriginal) => {
+      const orig = await importOriginal<typeof import('fs')>();
+      return { ...orig, existsSync: vi.fn().mockReturnValue(false) };
+    });
+
+    const { streamRoutes } = await import('../../src/playout/streamRoutes.js');
+    const app = Fastify();
+    await app.register(streamRoutes);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: `/stream/unknown-station-id/playlist.m3u8` });
+    expect(res.statusCode).toBe(404);
+
+    await app.close();
+  });
+});

--- a/services/station/src/queues/publishPipeline.ts
+++ b/services/station/src/queues/publishPipeline.ts
@@ -363,8 +363,12 @@ async function stageIngestProduction(scriptId: string, token: string): Promise<s
     throw new Error(`Ingest failed (${res.status}): ${body}`);
   }
 
-  const data = await res.json() as { script_id: string };
+  const data = await res.json() as { script_id: string; station_id: string; slug: string };
   if (!data.script_id) throw new Error('Ingest response missing script_id');
+  // Log for traceability: confirms which production station row was resolved (#449)
+  console.info(
+    `[stageIngestProduction] prod station_id=${data.station_id} (slug=${data.slug}) → script_id=${data.script_id}`,
+  );
   return data.script_id;
 }
 

--- a/services/station/src/routes/ingest.ts
+++ b/services/station/src/routes/ingest.ts
@@ -97,7 +97,7 @@ export async function ingestRoutes(app: FastifyInstance): Promise<void> {
            (company_id, name, slug, timezone, locale_code, city, country_code,
             callsign, tagline, frequency, is_active)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true)
-         ON CONFLICT (slug) WHERE slug IS NOT NULL
+         ON CONFLICT (company_id, slug) WHERE slug IS NOT NULL
          DO UPDATE SET
            name         = EXCLUDED.name,
            timezone     = EXCLUDED.timezone,

--- a/shared/db/src/migrations/064_scope_station_slug_to_company.sql
+++ b/shared/db/src/migrations/064_scope_station_slug_to_company.sql
@@ -1,0 +1,9 @@
+-- Re-scope stations.slug uniqueness from global to per-company.
+-- The old index made station slugs globally unique across all tenants;
+-- this caused `ingest-external` to link multiple companies' scripts to
+-- the same production station row when different tenants shared a slug.
+-- The new index enforces uniqueness only within a company (company_id, slug).
+DROP INDEX IF EXISTS stations_slug_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS stations_company_slug_unique
+  ON stations (company_id, slug)
+  WHERE slug IS NOT NULL;

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,12 +24,11 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 ---
 
 ## Active Work
-- [ ] fix(dj): stationId scoping in M3U8 builder and ingest (#449, fix/issue-449-station-scoping) | @claude-sonnet-4-6 | 2026-04-25 | Migration: 064
-- [ ] feat(station+scheduler): POST /stations/:id/generate-day orchestration route (#293, feat/issue-293-generate-day) | @claude-sonnet-4-6 | 2026-04-25
-- [ ] feat(dj+station+publish): full program audio in HLS stream — song audio in M3U8 + sourcing trigger in publish pipeline (feat/full-program-audio) | @claude-sonnet-4-6 | 2026-04-25
 - [ ] feat(frontend): Timeline multi-day view ?span=3 (#301, feat/issue-301) | @claude-code | 2026-04-13
 
 ## Recently Completed
+- [x] fix(dj+station): stationId scoping — per-company slug uniqueness + ingest ON CONFLICT + logging (#449, fix/issue-449-station-scoping, PR #453) | @claude-sonnet-4-6 | 2026-04-25 | Migration: 064
+- [x] feat(station+scheduler): POST /stations/:stationId/generate-day orchestration route (#293, feat/issue-293-generate-day, PR #452) | @claude-sonnet-4-6 | 2026-04-25
 - [x] fix(dj): segment pruning — skip orphaned DJ speech when song has no audio (#448-AC1, fix/issue-448-pruning, PR #451) | @claude-sonnet-4-6 | 2026-04-25
 - [x] feat(playlist+library): info-broker audio sourcing + /internal/songs/audio-sourced callback (feat/audio-sourcing-integration) | @claude-sonnet-4-6 | 2026-04-25
 - [x] feat(dj+gateway): OwnRadio HLS streaming integration (feat/ownradio-hls, main) | @claude-sonnet-4-6 | 2026-04-23


### PR DESCRIPTION
## Summary
- **Root cause**: `stations.slug` had a *global* unique index — two tenants sharing the same slug would upsert into the same station row, causing every station to serve the same M3U8 content
- **Migration 064**: replace `stations_slug_unique` (global) with `stations_company_slug_unique (company_id, slug)` (per-company)
- **`ingest-external`**: update `ON CONFLICT (slug)` → `ON CONFLICT (company_id, slug)` to match the new index
- **`publishPipeline`**: log resolved production `station_id + slug` after ingest for traceability (#449 AC)

## Acceptance Criteria
- [x] Root cause identified: global slug index allowed cross-tenant/cross-station collision
- [x] Fix: per-company slug uniqueness (migration 064)
- [x] Fix: `ingest-external` ON CONFLICT matches new index
- [x] Add log of resolved production `station_id` + `slug` in `stageIngestProduction`
- [x] Regression test: two stations → two different M3U8 responses (CDN segment URLs differ)
- [ ] Reproduce: publish two different stations and confirm their stream URLs return different M3U8 content (requires docker-compose stack)

## Test plan
- [x] `services/dj/tests/unit/streamRoutes.test.ts` — stationId scoping regression test (2 cases)
- [x] `pnpm run typecheck && pnpm run lint && pnpm run test:unit` all pass locally

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)