### PR TITLE
fix(station+public): persist stream_url and return it from public API

### DIFF
--- a/gateway/nginx.conf.template
+++ b/gateway/nginx.conf.template
@@ -94,9 +94,9 @@ server {
         proxy_set_header X-Request-ID $request_id;
     }
 
-    # ─── Scheduler: pipeline runs ───────────────────────────────
+    # ─── Station: pipeline runs (Radio Program Factory) ─────────
     location ~ ^/api/v1/stations/[^/]+/pipeline/ {
-        set $svc http://${SCHEDULER_HOST}:3004;
+        set $svc http://${STATION_HOST}:3002;
         proxy_pass $svc;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/services/station/src/queues/radioPipeline.ts
+++ b/services/station/src/queues/radioPipeline.ts
@@ -146,23 +146,28 @@ function sleep(ms: number): Promise<void> {
  * Returns the extracted value on success; throws on timeout.
  */
 async function pollUntil<T>(
-  url: string,
+  urlOrNull: string | null,
   token: string,
-  predicate: (body: unknown) => T | null,
+  predicate: ((body: unknown) => T | null) | (() => Promise<T | null>),
   intervalMs: number,
   timeoutMs: number,
   label: string,
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-    if (!res.ok) throw new Error(`${label}: poll GET ${url} returned ${res.status}`);
-    const body = await res.json();
-    const result = predicate(body);
+    let result: T | null;
+    if (urlOrNull) {
+      const res = await fetch(urlOrNull, { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) throw new Error(`${label}: poll GET ${urlOrNull} returned ${res.status}`);
+      const body = await res.json();
+      result = (predicate as (body: unknown) => T | null)(body);
+    } else {
+      result = await (predicate as () => Promise<T | null>)();
+    }
     if (result !== null) return result;
     await sleep(intervalMs);
   }
-  throw new Error(`${label}: timed out after ${timeoutMs / 1000}s polling ${url}`);
+  throw new Error(`${label}: timed out after ${timeoutMs / 1000}s`);
 }
 
 // ── Stage implementations ─────────────────────────────────────────────────────
@@ -190,19 +195,22 @@ async function stageGeneratePlaylist(
   const jobId = triggerData.job_id;
   if (!jobId) throw new Error('generate_playlist: scheduler did not return job_id');
 
-  // Poll until completed or failed (max 120s, every 3s)
+  // Poll the playlists table directly (shared DB) instead of the scheduler's
+  // job status API which requires UUID-format job IDs and auth.
+  const pool = getPool();
   const playlistId = await pollUntil<string>(
-    `${SCHEDULER_URL()}/api/v1/jobs/${jobId}`,
+    null, // no URL — we poll the DB
     token,
-    (body) => {
-      const b = body as { state?: string; returnvalue?: { playlistId?: string }; failedReason?: string };
-      if (b.state === 'failed') {
-        throw new Error(`generate_playlist: scheduler job failed — ${b.failedReason ?? 'unknown'}`);
-      }
-      if (b.state === 'completed' && b.returnvalue?.playlistId) {
-        return b.returnvalue.playlistId;
-      }
-      return null;
+    async () => {
+      const { rows } = await pool.query<{ id: string; status: string }>(
+        `SELECT id, status FROM playlists WHERE station_id = $1 AND date = $2 ORDER BY generated_at DESC NULLS LAST LIMIT 1`,
+        [stationId, date],
+      );
+      const pl = rows[0];
+      if (!pl) return null;
+      if (pl.status === 'failed') throw new Error('generate_playlist: playlist generation failed');
+      if (pl.status === 'ready' || pl.status === 'approved') return pl.id;
+      return null; // still generating
     },
     3000,
     120_000,

--- a/services/station/src/routes/ingest.ts
+++ b/services/station/src/routes/ingest.ts
@@ -289,10 +289,17 @@ export async function ingestRoutes(app: FastifyInstance): Promise<void> {
       // ── 8. Auto-register station in OwnRadio + notify stream URL ──────
       const ownradioUrl = process.env.OWNRADIO_WEBHOOK_URL;
       const webhookSecret = process.env.PLAYGEN_WEBHOOK_SECRET;
+      const gatewayUrl = process.env.GATEWAY_URL ?? process.env.PROD_GATEWAY_URL ?? 'https://api.playgen.site';
+      const stationStreamUrl = stream_url ?? `${gatewayUrl}/stream/${station_id}/playlist.m3u8`;
+
+      // Persist stream_url on the station record so public API can return it
+      await pool.query(
+        `UPDATE stations SET stream_url = $1, updated_at = NOW() WHERE id = $2`,
+        [stationStreamUrl, station_id],
+      );
+
       if (ownradioUrl && stationData.slug) {
         // Upsert station in OwnRadio (creates if not exists, updates if exists)
-        const gatewayUrl = process.env.GATEWAY_URL ?? process.env.PROD_GATEWAY_URL ?? 'https://api.playgen.site';
-        const stationStreamUrl = stream_url ?? `${gatewayUrl}/stream/${station_id}/playlist.m3u8`;
         fetch(`${ownradioUrl}/stations`, {
           method: 'POST',
           headers: {

--- a/services/station/src/routes/publicStations.ts
+++ b/services/station/src/routes/publicStations.ts
@@ -26,6 +26,12 @@ function formatDj(d: DjRow) {
   };
 }
 
+const GATEWAY_URL = process.env.GATEWAY_URL ?? process.env.PROD_GATEWAY_URL ?? 'https://api.playgen.site';
+
+function resolveStreamUrl(stationId: string, stored: string | null): string {
+  return stored ?? `${GATEWAY_URL}/stream/${stationId}/playlist.m3u8`;
+}
+
 export async function publicStationRoutes(app: FastifyInstance) {
   // GET /public/stations — list all active stations with all assigned DJs
   app.get('/public/stations', async () => {
@@ -34,7 +40,7 @@ export async function publicStationRoutes(app: FastifyInstance) {
     const { rows: stations } = await pool.query(`
       SELECT id, name, slug, timezone, locale_code, city, country_code,
         callsign, tagline, frequency, is_active, dj_enabled,
-        logo_url, primary_color, secondary_color
+        logo_url, primary_color, secondary_color, stream_url
       FROM stations
       WHERE is_active = true AND slug IS NOT NULL
       ORDER BY name ASC
@@ -70,7 +76,7 @@ export async function publicStationRoutes(app: FastifyInstance) {
         name: s.name,
         slug: s.slug,
         description: s.tagline ?? '',
-        streamUrl: '',
+        streamUrl: resolveStreamUrl(s.id, s.stream_url),
         metadataUrl: '',
         genre: '',
         artworkUrl: s.logo_url ?? null,
@@ -90,7 +96,7 @@ export async function publicStationRoutes(app: FastifyInstance) {
     const { rows } = await pool.query(`
       SELECT id, name, slug, timezone, locale_code, city, country_code,
         callsign, tagline, frequency, is_active, dj_enabled,
-        logo_url, primary_color, secondary_color
+        logo_url, primary_color, secondary_color, stream_url
       FROM stations
       WHERE slug = $1 AND is_active = true
     `, [req.params.slug]);
@@ -114,7 +120,7 @@ export async function publicStationRoutes(app: FastifyInstance) {
       name: st.name,
       slug: st.slug,
       description: st.tagline ?? '',
-      streamUrl: '',
+      streamUrl: resolveStreamUrl(st.id, st.stream_url),
       metadataUrl: '',
       genre: '',
       artworkUrl: st.logo_url ?? null,

--- a/services/station/src/routes/radioPipeline.ts
+++ b/services/station/src/routes/radioPipeline.ts
@@ -71,9 +71,9 @@ export default async function radioPipelineRoutes(app: FastifyInstance): Promise
       });
 
       const { rows: runRows } = await pool.query<{ id: string }>(
-        `INSERT INTO pipeline_runs (station_id, status, config)
-         VALUES ($1, 'queued', $2) RETURNING id`,
-        [station_id, config],
+        `INSERT INTO pipeline_runs (station_id, date, status, config)
+         VALUES ($1, $2, 'queued', $3) RETURNING id`,
+        [station_id, date, config],
       );
       const pipeline_run_id = runRows[0].id;
 

--- a/services/station/src/services/streamControlNotifier.ts
+++ b/services/station/src/services/streamControlNotifier.ts
@@ -14,6 +14,30 @@ function webhookHeaders(): Record<string, string> {
   return headers;
 }
 
+/**
+ * Ensure a station exists in OwnRadio's DB before sending stream control events.
+ * Calls POST /stations which upserts by slug (creates if missing, updates if exists).
+ */
+export async function ensureStationOnOwnRadio(station: {
+  slug: string;
+  name: string;
+  streamUrl?: string;
+  genre?: string;
+  isLive?: boolean;
+  dj?: { name: string; bio?: string };
+}): Promise<void> {
+  if (!OWNRADIO_WEBHOOK_URL) return;
+  const res = await fetch(`${OWNRADIO_WEBHOOK_URL}/stations`, {
+    method: 'POST',
+    headers: webhookHeaders(),
+    body: JSON.stringify(station),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`OwnRadio station upsert failed (${res.status}): ${body}`);
+  }
+}
+
 export async function notifyStreamUrlChange(slug: string, streamUrl: string): Promise<void> {
   if (!OWNRADIO_WEBHOOK_URL) return;
   await fetch(`${OWNRADIO_WEBHOOK_URL}/webhooks/stations/${slug}/stream-control`, {

--- a/shared/db/package.json
+++ b/shared/db/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc && cp src/migrations/*.sql dist/migrations/",
+    "build": "tsc && mkdir -p dist/migrations && cp src/migrations/*.sql dist/migrations/",
     "typecheck": "tsc --noEmit",
     "migrate": "node dist/migrate.js",
     "seed": "node dist/seeds/index.js",

--- a/shared/db/package.json
+++ b/shared/db/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/migrations/*.sql dist/migrations/",
     "typecheck": "tsc --noEmit",
     "migrate": "node dist/migrate.js",
     "seed": "node dist/seeds/index.js",

--- a/shared/db/src/migrations/069_add_stream_url_to_stations.sql
+++ b/shared/db/src/migrations/069_add_stream_url_to_stations.sql
@@ -1,0 +1,5 @@
+-- Add stream_url to stations for persisting HLS playlist URL from publish pipeline
+ALTER TABLE stations
+  ADD COLUMN IF NOT EXISTS stream_url VARCHAR(1000);
+
+COMMENT ON COLUMN stations.stream_url IS 'HLS playlist URL (R2 public URL) set by the publish pipeline; used by public API to return the stream endpoint';


### PR DESCRIPTION
## Summary

- **Root cause of #32 stream issue**: `publicStations.ts` hardcoded `streamUrl: ''` — the HLS playlist URL was never stored on the station record nor returned via the public API
- Migration 069 adds `stream_url` column to `stations` table
- `ingest-external` now persists the computed `stationStreamUrl` to the DB after every publish
- `publicStations` returns `stream_url` from DB, falling back to `${GATEWAY_URL}/stream/:id/playlist.m3u8` for stations without a stored URL (covers all existing stations immediately after deploy)
- `db/package.json` build script now copies `.sql` files to `dist/migrations/` to prevent silent migration skips

Also includes pipeline fixes from previous session:
- nginx: `pipeline/*` routes go to station service (not scheduler)
- `radioPipeline.ts`: poll DB directly for playlist completion instead of scheduler job API
- `streamControlNotifier.ts`: extracted module for OwnRadio stream URL notifications

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — warnings only (no errors)
- [x] `pnpm run test:unit` — 161+25+41+44 = 271 tests passing
- [x] Local: `GET /api/v1/public/stations` returns `streamUrl: "https://api.playgen.site/stream/..."` for all stations
- [ ] Production: after Railway deploys, verify `GET /api/v1/public/stations` returns non-empty `streamUrl`
- [ ] ownradio.net OwnRadio Manila: player connects and stream plays (no "Coming Soon")

🤖 Generated with [Claude Code](https://claude.com/claude-code)