### PR TITLE
fix(station): document LOCAL_MUSIC_DIR in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,10 @@ INFO_BROKER_URL=http://info-broker.railway.internal:8000
 INFO_BROKER_API_KEY=
 # PlayGen's own base URL — sent to info-broker as the callback root
 PLAYGEN_INTERNAL_URL=https://api.playgen.site
+
+# ─── Local dev: music library mount ────────────────────────────────────────────
+# Absolute path to your local music library on the host machine.
+# Mounted read-only into the station container at /library (via docker-compose.override.yml).
+# Required only for local publish pipeline runs where songs have host filesystem paths.
+# Leave empty in production — songs arrive with CDN URLs from the info-broker pipeline.
+LOCAL_MUSIC_DIR=

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -24,6 +24,7 @@ _(no open bugs — check GitHub Issues for new P0/P1 bugs)_
 ---
 
 ## Active Work
+- [ ] fix(station): mount local music lib into station container via env-var volume (#533, feat/issue-533-local-music-mount) | @claude-sonnet-4-6 | 2026-05-02
 - [x] feat(dj): parallel TTS generation — concurrency-limited batching with TTS_WORKER_CONCURRENCY (#424, feat/issue-424-parallel-tts, PR #454) | @claude-sonnet-4-6 | 2026-04-25
 - [x] fix(station+public): persist stream_url from publish pipeline + public endpoint returns it (#32, fix/ownradio-stream-url, PR #526) | @claude-sonnet-4-6 | 2026-04-27 | Migration: 069
 - [x] feat(dj+station+public): DALL-E 3 DJ avatar + station artwork generation, exposed in public stations API | @claude-sonnet-4-6 | 2026-04-28 | Migrations: 071, 072


### PR DESCRIPTION
Adds LOCAL_MUSIC_DIR= to .env.example. docker-compose.override.yml and publishPipeline.ts remapping were already in main. Closes #533