### PR TITLE
feat(pipeline): fix gateway routing for pipeline retry endpoint + unit tests

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -119,6 +119,21 @@ server {
         proxy_set_header X-Request-ID $request_id;
     }
 
+    # ─── Scheduler: pipeline retry + latest run ───────────────────
+    location ~ ^/api/v1/stations/[^/]+/pipeline/runs/[^/]+/retry {
+        proxy_pass http://scheduler;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
+    }
+
+    location ~ ^/api/v1/stations/[^/]+/pipeline/runs/latest {
+        proxy_pass http://scheduler;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
+    }
+
     # ─── Playlist: station playlists list ────────────────────────
     location ~ ^/api/v1/stations/[^/]+/playlists {
         proxy_pass http://playlist;

--- a/services/scheduler/src/services/pipelineTracker.ts
+++ b/services/scheduler/src/services/pipelineTracker.ts
@@ -46,6 +46,15 @@ const STAGE_COLUMN: Record<PipelineStage, string> = {
   publish: 'stage_publish',
 };
 
+/** Ordered list of all pipeline stages — exported for tests and route validation. */
+export const PIPELINE_STAGES: PipelineStage[] = ['playlist', 'dj_script', 'review', 'tts', 'publish'];
+
+/** Returns the stages that come after `stage` in the pipeline (will be reset to 'pending' on retry). */
+export function getDownstreamStages(stage: PipelineStage): PipelineStage[] {
+  const idx = PIPELINE_STAGES.indexOf(stage);
+  return idx === -1 ? [] : PIPELINE_STAGES.slice(idx + 1);
+}
+
 /**
  * Create a new pipeline run. Returns the run ID.
  */
@@ -196,22 +205,19 @@ export async function findActiveRun(stationId: string, date: string): Promise<st
   return rows[0]?.id ?? null;
 }
 
-const STAGE_ORDER: PipelineStage[] = ['playlist', 'dj_script', 'review', 'tts', 'publish'];
-
 /**
  * Retry a failed stage: reset it to 'running', reset all downstream stages to 'pending',
  * and set the overall run back to 'running'.
  */
 export async function retryStage(runId: string, stage: PipelineStage): Promise<void> {
   const pool = getPool();
-  const stageIdx = STAGE_ORDER.indexOf(stage);
 
   // Build SET clauses: retry stage → running, downstream stages → pending
   const sets: string[] = [
     `${STAGE_COLUMN[stage]} = '{"status":"running","started_at":"${new Date().toISOString()}"}'::jsonb`,
   ];
-  for (let i = stageIdx + 1; i < STAGE_ORDER.length; i++) {
-    sets.push(`${STAGE_COLUMN[STAGE_ORDER[i]]} = '{"status":"pending"}'::jsonb`);
+  for (const downstream of getDownstreamStages(stage)) {
+    sets.push(`${STAGE_COLUMN[downstream]} = '{"status":"pending"}'::jsonb`);
   }
   sets.push(`status = 'running'`);
   sets.push(`updated_at = NOW()`);

--- a/services/scheduler/tests/unit/pipelineRetry.test.ts
+++ b/services/scheduler/tests/unit/pipelineRetry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { PIPELINE_STAGES, getDownstreamStages, type PipelineStage } from '../../src/services/pipelineTracker.js';
+
+describe('PIPELINE_STAGES', () => {
+  it('contains all 5 stages in order', () => {
+    expect(PIPELINE_STAGES).toEqual(['playlist', 'dj_script', 'review', 'tts', 'publish']);
+  });
+
+  it('has no duplicate stages', () => {
+    expect(new Set(PIPELINE_STAGES).size).toBe(PIPELINE_STAGES.length);
+  });
+});
+
+describe('getDownstreamStages', () => {
+  it('returns all stages after playlist (4 downstream)', () => {
+    expect(getDownstreamStages('playlist')).toEqual(['dj_script', 'review', 'tts', 'publish']);
+  });
+
+  it('returns stages after dj_script (3 downstream)', () => {
+    expect(getDownstreamStages('dj_script')).toEqual(['review', 'tts', 'publish']);
+  });
+
+  it('returns stages after review (2 downstream)', () => {
+    expect(getDownstreamStages('review')).toEqual(['tts', 'publish']);
+  });
+
+  it('returns stages after tts (1 downstream)', () => {
+    expect(getDownstreamStages('tts')).toEqual(['publish']);
+  });
+
+  it('returns empty array for publish (last stage — no downstream)', () => {
+    expect(getDownstreamStages('publish')).toEqual([]);
+  });
+
+  it('retried stage itself is NOT included in downstream', () => {
+    for (const stage of PIPELINE_STAGES) {
+      expect(getDownstreamStages(stage)).not.toContain(stage);
+    }
+  });
+
+  it('all returned stages appear after the retried stage in PIPELINE_STAGES', () => {
+    for (const stage of PIPELINE_STAGES) {
+      const stageIdx = PIPELINE_STAGES.indexOf(stage);
+      const downstream = getDownstreamStages(stage);
+      for (const ds of downstream) {
+        expect(PIPELINE_STAGES.indexOf(ds)).toBeGreaterThan(stageIdx);
+      }
+    }
+  });
+});
+
+describe('pipeline stage validation', () => {
+  const VALID_STAGES = new Set<string>(PIPELINE_STAGES);
+
+  it('accepts all valid stage names', () => {
+    const valid: PipelineStage[] = ['playlist', 'dj_script', 'review', 'tts', 'publish'];
+    for (const s of valid) {
+      expect(VALID_STAGES.has(s)).toBe(true);
+    }
+  });
+
+  it('rejects invalid stage names', () => {
+    const invalid = ['upload_assets', 'validate', 'ingest', '', 'PLAYLIST', 'script'];
+    for (const s of invalid) {
+      expect(VALID_STAGES.has(s)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the gateway so POST /api/v1/stations/:id/pipeline/runs/:runId/retry/:stage routes to the scheduler service (where the retry logic lives), not the station service catch-all
- Also routes GET .../pipeline/runs/latest to scheduler
- Exports PIPELINE_STAGES and getDownstreamStages() from pipelineTracker.ts for testability
- Adds 11 unit tests covering stage ordering, downstream reset logic, and stage validation

## Root Cause

The retry endpoint was fully implemented in services/scheduler/src/routes/pipeline.ts but the nginx gateway catch-all (location ~ ^/api/v1/stations) routed to the station service, which has no retry route. Adding a specific location block before the catch-all fixes routing.

## Acceptance Criteria

- [x] Retry button visible on failed stages (frontend already had it)
- [x] Each stage retry calls the correct existing endpoint (scheduler logic was complete)
- [x] Pipeline run status resets from failed to running on retry (retryStage() handles this)
- [x] Retried stage resets to running with new started_at
- [x] Downstream stages reset to pending
- [x] UI polls and shows retry progress (2s polling was already in frontend)

Closes #501

Generated with Claude Code