### PR TITLE
fix(dj+station): LLM/TTS exponential backoff, checkpoint resume, pipeline progress (#529)

### DIFF
--- a/services/dj/src/utils/retry.ts
+++ b/services/dj/src/utils/retry.ts
@@ -5,7 +5,7 @@
  * Non-retryable errors (400, 401, 404, etc.) are rethrown immediately.
  */
 
-const BASE_DELAY_MS = 1_000;
+const BASE_DELAY_MS = process.env.NODE_ENV === 'test' ? 10 : 1_000;
 const MAX_DELAY_MS = 30_000;
 
 /** True for errors that are worth retrying (rate limits, transient server errors). */
@@ -34,13 +34,20 @@ function parseRetryAfterMs(err: unknown): number | null {
   return null;
 }
 
+export interface RetryOptions {
+  /** Label for log messages (e.g. 'non-song/show_intro'). */
+  label?: string;
+  /** Override max attempts (default 3). */
+  maxAttempts?: number;
+}
+
 /**
  * Retry `fn` up to `maxAttempts` times with exponential backoff + jitter.
  * Non-retryable errors are rethrown immediately (no retry delay wasted).
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
-  { maxAttempts = 3, label = 'call' }: { maxAttempts?: number; label?: string } = {},
+  { maxAttempts = 3, label = 'call' }: RetryOptions = {},
 ): Promise<T> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -49,7 +56,7 @@ export async function withRetry<T>(
       if (!isRetryable(err) || attempt === maxAttempts) throw err;
       const retryAfterMs = parseRetryAfterMs(err);
       const backoffMs = retryAfterMs ?? Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
-      const jitter = Math.random() * 500;
+      const jitter = process.env.NODE_ENV === 'test' ? 0 : Math.random() * 500;
       const delayMs = Math.round(backoffMs + jitter);
       console.warn(
         `[retry] ${label} failed (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs}ms: ${(err as Error).message}`,

--- a/services/dj/src/workers/generationWorker.ts
+++ b/services/dj/src/workers/generationWorker.ts
@@ -361,28 +361,56 @@ export async function runGenerationJob(
       .map((s) => ({ id: '', listener_name: s.listener_name, message: s.message })),
   ].slice(0, 3);
 
-  // 5. Create the script record (with multi-DJ fields when applicable)
+  // 5. Find or create the script record (checkpoint resume on retry)
   const voiceMap = isDualDj
     ? (data.voice_map ?? Object.fromEntries(allProfiles.map((p) => [p.name, p.tts_voice_id])))
     : null;
 
-  const { rows: scriptRows } = await pool.query(
-    `INSERT INTO dj_scripts
-       (playlist_id, station_id, dj_profile_id, secondary_dj_profile_id,
-        review_status, llm_model, total_segments, voice_map)
-     VALUES ($1, $2, $3, $4, $5, $6, 0, $7)
-     RETURNING id`,
-    [
-      data.playlist_id,
-      data.station_id,
-      profile.id,
-      secondaryProfile?.id ?? null,
-      data.auto_approve ? 'auto_approved' : 'pending_review',
-      profile.llm_model,
-      voiceMap ? JSON.stringify(voiceMap) : null,
-    ],
+  // Check for existing incomplete script for this playlist (generation_ms IS NULL = not finished)
+  const { rows: existingScriptRows } = await pool.query<{ id: string }>(
+    `SELECT id FROM dj_scripts
+     WHERE playlist_id = $1 AND station_id = $2 AND generation_ms IS NULL
+     ORDER BY created_at DESC LIMIT 1`,
+    [data.playlist_id, data.station_id],
   );
-  const script_id: string = scriptRows[0].id;
+  const existingScript = existingScriptRows[0];
+
+  // Track already-generated positions for checkpoint resume
+  const donePositions = new Set<number>();
+  const resumeSegmentTexts = new Map<number, string>();
+  let script_id: string;
+
+  // Always query existing segments (WHERE script_id = NULL returns [] when no prior script found)
+  const { rows: existingSegments } = await pool.query<{ position: number; script_text: string }>(
+    `SELECT position, script_text FROM dj_segments WHERE script_id = $1 ORDER BY position`,
+    [existingScript?.id ?? null],
+  );
+  for (const seg of existingSegments) {
+    donePositions.add(seg.position);
+    resumeSegmentTexts.set(seg.position, seg.script_text);
+  }
+
+  if (existingScript) {
+    script_id = existingScript.id;
+  } else {
+    const { rows: scriptRows } = await pool.query(
+      `INSERT INTO dj_scripts
+         (playlist_id, station_id, dj_profile_id, secondary_dj_profile_id,
+          review_status, llm_model, total_segments, voice_map)
+       VALUES ($1, $2, $3, $4, $5, $6, 0, $7)
+       RETURNING id`,
+      [
+        data.playlist_id,
+        data.station_id,
+        profile.id,
+        secondaryProfile?.id ?? null,
+        data.auto_approve ? 'auto_approved' : 'pending_review',
+        profile.llm_model,
+        voiceMap ? JSON.stringify(voiceMap) : null,
+      ],
+    );
+    script_id = scriptRows[0].id;
+  }
 
   // 5b. Load program themes for this station/hour and resolve directives
   const { resolveThemeDirectives, formatDirectivesForSegment } = await import('../lib/themeResolver.js');
@@ -456,6 +484,13 @@ export async function runGenerationJob(
   // Running list of generated texts — passed to each LLM call to enforce variety
   const generatedTexts: string[] = [];
 
+  // Pre-populate generatedTexts from already-done segments (for variety context on resume)
+  if (donePositions.size > 0) {
+    for (const [, text] of [...resumeSegmentTexts.entries()].sort(([a], [b]) => a - b)) {
+      generatedTexts.push(text);
+    }
+  }
+
   // Pre-count total segment slots for progress reporting (approximate — non-song segments added dynamically)
   let totalSegmentSlots = 0;
   for (let i = 0; i < entries.length; i++) {
@@ -500,6 +535,14 @@ export async function runGenerationJob(
       : buildSystemPrompt(profile!, station.locale_code, effectiveTtsProvider);
     const userPrompt = buildUserPrompt(ctx) + rejectionContext;
 
+    // Resume checkpoint: skip if this position was already inserted in a previous attempt
+    const previewPosNonSong = position;
+    if (donePositions.has(previewPosNonSong)) {
+      position++;
+      generatedTexts.push(resumeSegmentTexts.get(previewPosNonSong) ?? '');
+      return;
+    }
+
     // Soft rate limit check — skip segment rather than abort the whole script
     const llmRateCheck = await checkLlmRateLimit(data.station_id);
     if (!llmRateCheck.allowed) {
@@ -512,7 +555,7 @@ export async function runGenerationJob(
     );
     let script_text: string;
     try {
-      const llmResult = await llmComplete(
+      const llmResult = await withRetry(() => llmComplete(
         [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt },
@@ -523,7 +566,7 @@ export async function runGenerationJob(
           apiKey: effectiveLlmApiKey ?? undefined,
           provider: effectiveLlmProvider,
         },
-      );
+      ), { label: `non-song/${segment_type}` });
       script_text = llmResult.text;
       if (llmResult.usage) {
         logLlmUsage({
@@ -537,7 +580,7 @@ export async function runGenerationJob(
       }
     } catch (llmErr) {
       console.error(
-        `[generationWorker] LLM call FAILED — provider=${effectiveLlmProvider} model=${effectiveLlmModel} error:`,
+        `[generationWorker] LLM call FAILED permanently (3 retries) — provider=${effectiveLlmProvider} model=${effectiveLlmModel} segment=${segment_type}:`,
         llmErr,
       );
       throw llmErr;
@@ -717,6 +760,15 @@ export async function runGenerationJob(
       const llmProgress = 10 + Math.round((segmentsDone / totalSegmentSlots) * 80);
       await reportProgress(llmProgress, `Writing ${segment_type.replace('_', ' ')} (${segmentsDone + 1}/${totalSegmentSlots})…`);
 
+      // Checkpoint: skip already-inserted positions from a previous attempt
+      const currentPos = position;
+      if (donePositions.has(currentPos)) {
+        position++;
+        generatedTexts.push(resumeSegmentTexts.get(currentPos) ?? '');
+        segmentsDone++;
+        continue;
+      }
+
       // Soft rate limit check — skip segment rather than abort the whole script
       const llmRateCheckSong = await checkLlmRateLimit(data.station_id);
       if (!llmRateCheckSong.allowed) {
@@ -727,17 +779,20 @@ export async function runGenerationJob(
 
       let script_text: string;
       try {
-        const llmResult = await llmComplete(
-          [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt },
-          ],
-          {
-            model: effectiveLlmModel,
-            temperature: profile.llm_temperature != null ? Number(profile.llm_temperature) : undefined,
-            apiKey: effectiveLlmApiKey ?? undefined,
-            provider: effectiveLlmProvider,
-          },
+        const llmResult = await withRetry(
+          () => llmComplete(
+            [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            {
+              model: effectiveLlmModel,
+              temperature: profile.llm_temperature != null ? Number(profile.llm_temperature) : undefined,
+              apiKey: effectiveLlmApiKey ?? undefined,
+              provider: effectiveLlmProvider,
+            },
+          ),
+          { label: `song/${segment_type}` },
         );
         script_text = llmResult.text;
         if (llmResult.usage) {
@@ -752,7 +807,7 @@ export async function runGenerationJob(
         }
       } catch (llmErr) {
         console.error(
-          `[generationWorker] LLM call FAILED — provider=${effectiveLlmProvider} model=${effectiveLlmModel} error:`,
+          `[generationWorker] LLM call FAILED permanently (3 retries) — provider=${effectiveLlmProvider} model=${effectiveLlmModel} segment=${segment_type}:`,
           llmErr,
         );
         throw llmErr;

--- a/services/dj/tests/unit/generationWorker.test.ts
+++ b/services/dj/tests/unit/generationWorker.test.ts
@@ -130,12 +130,16 @@ describe('generationWorker', () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
     // 4c. Pending shoutouts (none)
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // 5. Script insert
+    // 5. Existing script check (none — fresh run)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5a. Segments resume query — always executes (WHERE script_id = NULL → empty result)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5b. Script insert
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: scriptId }],
     });
 
-    // 5b. Program themes query (no active themes)
+    // 5c. Program themes query (no active themes)
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     // For 1 entry, segmentsForEntry returns ['show_intro', 'song_intro', 'show_outro']
@@ -207,10 +211,14 @@ describe('generationWorker', () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: 'shoutout-1', listener_name: 'Maria', message: 'Love the morning show!' }],
     });
-    // 5. Script insert
+    // 5. Existing script check (none — fresh run)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5a. Segments resume query — always executes (WHERE script_id = NULL → empty result)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5b. Script insert
     mockQuery.mockResolvedValueOnce({ rows: [{ id: scriptId }] });
 
-    // 5b. Program themes query (no active themes)
+    // 5c. Program themes query (no active themes)
     mockQuery.mockResolvedValueOnce({ rows: [] });
 
     // 6. Segment inserts (main loop uses RETURNING id; shoutout INSERT does not)
@@ -280,7 +288,11 @@ describe('generationWorker', () => {
     });
     // 4c. Pending shoutouts (none)
     mockQuery.mockResolvedValueOnce({ rows: [] });
-    // 5. Script insert
+    // 5. Existing script check (none — fresh run)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5a. Segments resume query — always executes (WHERE script_id = NULL → empty result)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5b. Script insert
     mockQuery.mockResolvedValueOnce({ rows: [{ id: scriptId }] });
 
     // 6. Segment inserts (show_intro, song_intro, station_id, song_transition×3, show_outro + 2 adlibs at interval 1)

--- a/services/dj/tests/unit/pipelineRetryResume.test.ts
+++ b/services/dj/tests/unit/pipelineRetryResume.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for issue #529: pipeline stage retry, LLM/TTS backoff, and checkpoint resume.
+ *
+ * Covers:
+ * - AC1: LLM calls retry with exponential backoff on 429/5xx
+ * - AC3: DJ generation resumes from last completed segment on job retry
+ * - AC5: Failed segments are logged with error details
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (must come before imports) ──────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock('pg', () => ({
+  Pool: vi.fn().mockImplementation(class {
+    query = mockQuery;
+    on = vi.fn();
+  }),
+}));
+
+// LLM adapter mock — starts as always-succeed, overridden per test
+const mockLlmComplete = vi.fn().mockResolvedValue({ text: 'Generated text' });
+
+vi.mock('../../src/adapters/llm/index.js', () => ({
+  llmComplete: (...args: unknown[]) => mockLlmComplete(...args),
+}));
+
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(class {
+    chat = { completions: { create: vi.fn() } };
+    audio = { speech: { create: vi.fn() } };
+  }),
+}));
+
+vi.mock('../config.js', () => ({
+  config: {
+    tts: { openaiApiKey: 'test-key', elevenlabsApiKey: 'test-key', provider: 'openai' },
+    storage: { localPath: '/tmp/playgen-dj' },
+    openRouter: { defaultModel: 'test-model' },
+    llm: { backend: 'openrouter' },
+  },
+}));
+
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ size: 1024 }),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../src/services/manifestService.js', () => ({
+  buildManifest: vi.fn().mockResolvedValue(undefined),
+  getManifestByScript: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/adapters/news/index.js', () => ({
+  getNewsProvider: vi.fn(() => ({ fetchHeadlines: vi.fn().mockResolvedValue([]) })),
+}));
+
+vi.mock('../../src/lib/rateLimiter.js', () => ({
+  checkLlmRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  checkTtsRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock('../../src/lib/usageLogger.js', () => ({
+  logLlmUsage: vi.fn(),
+  logTtsUsage: vi.fn(),
+}));
+
+vi.mock('../../src/adapters/social/index.js', () => ({
+  getSocialProviders: vi.fn().mockResolvedValue([]),
+}));
+
+// ── Import worker ──────────────────────────────────────────────────────────────
+
+import { runGenerationJob } from '../../src/workers/generationWorker';
+
+// ── Helper: set up a standard fresh-run mock sequence ─────────────────────────
+
+function setupFreshRunMocks(scriptId: string, overrides?: { existingScript?: string; existingSegments?: Array<{ position: number; script_text: string }> }) {
+  // 1. Station info
+  mockQuery.mockResolvedValueOnce({
+    rows: [{ id: 'station-1', name: 'Test FM', timezone: 'UTC', company_id: 'co-1', openrouter_api_key: 'key' }],
+  });
+  // 1b. Station settings
+  mockQuery.mockResolvedValueOnce({ rows: [{ key: 'llm_api_key', value: 'test-key' }] });
+  // 2. DJ profile
+  mockQuery.mockResolvedValueOnce({
+    rows: [{ id: 'profile-1', llm_model: 'test-model', llm_temperature: 0.8, tts_voice_id: 'alloy' }],
+  });
+  // 3. Playlist entries (1 entry)
+  mockQuery.mockResolvedValueOnce({
+    rows: [{ id: 'entry-1', hour: 10, position: 0, song_title: 'Song', song_artist: 'Artist', duration_sec: 180 }],
+  });
+  // 4. Script templates
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  // 4b. Adlib clips
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  // 4c. Pending shoutouts
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  // 5. Existing incomplete script check
+  if (overrides?.existingScript) {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: overrides.existingScript }] });
+  } else {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // no existing script
+  }
+  // 5a. Segments resume query — ALWAYS runs (WHERE script_id = NULL → empty on fresh run)
+  const existingSegs = overrides?.existingSegments ?? [];
+  mockQuery.mockResolvedValueOnce({ rows: existingSegs });
+  if (!overrides?.existingScript) {
+    // INSERT new script (only on fresh run)
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: scriptId }] });
+  }
+  // 5b. Program themes
+  mockQuery.mockResolvedValueOnce({ rows: [] });
+  // Segment inserts + final update — fall back to default
+  mockQuery.mockResolvedValue({ rows: [{ id: 'seg-x' }] });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('pipeline retry, backoff, and resume (#529)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    mockLlmComplete.mockResolvedValue({ text: 'Generated text' });
+  });
+
+  // ── AC1: LLM retry on 429 ──────────────────────────────────────────────────
+
+  describe('AC1 — LLM retry with exponential backoff', () => {
+    it('retries an LLM call that fails with 429 and eventually succeeds', async () => {
+      // First call: 429 rate limit; second call: success
+      mockLlmComplete
+        .mockRejectedValueOnce(new Error('Request failed with status 429: Too Many Requests'))
+        .mockResolvedValue({ text: 'Retried successfully' });
+
+      setupFreshRunMocks('script-retry');
+
+      await runGenerationJob({
+        playlist_id: 'playlist-1',
+        station_id: 'station-1',
+        auto_approve: false,
+      });
+
+      // LLM was called more than once — first call failed with 429, retry succeeded
+      expect(mockLlmComplete.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('throws after exhausting all retries on persistent 429', async () => {
+      // All 3 attempts fail
+      mockLlmComplete.mockRejectedValue(new Error('Request failed with status 429: Too Many Requests'));
+
+      // Set up mocks only up to the first LLM call
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 'station-1', name: 'FM', timezone: 'UTC', company_id: 'co-1' }] }) // station
+        .mockResolvedValueOnce({ rows: [{ key: 'llm_api_key', value: 'key' }] }) // settings
+        .mockResolvedValueOnce({ rows: [{ id: 'p-1', llm_model: 'model', llm_temperature: 0.8, tts_voice_id: 'alloy' }] }) // profile
+        .mockResolvedValueOnce({ rows: [{ id: 'e1', hour: 10, position: 0, song_title: 'S', song_artist: 'A', duration_sec: 180 }] }) // playlist
+        .mockResolvedValueOnce({ rows: [] }) // templates
+        .mockResolvedValueOnce({ rows: [] }) // adlibs
+        .mockResolvedValueOnce({ rows: [] }) // shoutouts
+        .mockResolvedValueOnce({ rows: [] }) // existing script check
+        .mockResolvedValueOnce({ rows: [] }) // existing segments
+        .mockResolvedValueOnce({ rows: [{ id: 'script-fail' }] }) // script insert
+        .mockResolvedValueOnce({ rows: [] }); // program themes
+
+      await expect(
+        runGenerationJob({ playlist_id: 'playlist-1', station_id: 'station-1', auto_approve: false }),
+      ).rejects.toThrow();
+
+      // All 3 attempts should have been made
+      expect(mockLlmComplete).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry non-retryable errors (e.g. 401 unauthorized)', async () => {
+      mockLlmComplete.mockRejectedValue(new Error('Request failed with status 401: Unauthorized'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 'station-1', name: 'FM', timezone: 'UTC', company_id: 'co-1' }] })
+        .mockResolvedValueOnce({ rows: [{ key: 'llm_api_key', value: 'key' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 'p-1', llm_model: 'model', llm_temperature: 0.8, tts_voice_id: 'alloy' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 'e1', hour: 10, position: 0, song_title: 'S', song_artist: 'A', duration_sec: 180 }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] }) // existing script check
+        .mockResolvedValueOnce({ rows: [] }) // existing segments
+        .mockResolvedValueOnce({ rows: [{ id: 'script-auth-fail' }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await expect(
+        runGenerationJob({ playlist_id: 'playlist-1', station_id: 'station-1', auto_approve: false }),
+      ).rejects.toThrow('401');
+
+      // Should only be called once — no retries for 401
+      expect(mockLlmComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── AC3: Checkpoint resume ─────────────────────────────────────────────────
+
+  describe('AC3 — checkpoint resume on job retry', () => {
+    it('reuses existing incomplete script instead of creating a new one', async () => {
+      const existingScriptId = 'script-existing';
+      setupFreshRunMocks('script-new', {
+        existingScript: existingScriptId,
+        existingSegments: [],
+      });
+
+      await runGenerationJob({
+        playlist_id: 'playlist-1',
+        station_id: 'station-1',
+        auto_approve: false,
+      });
+
+      // INSERT INTO dj_scripts should NOT have been called
+      const insertScriptCalls = (mockQuery.mock.calls as unknown as Array<[string, unknown[]]>).filter(
+        ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO dj_scripts'),
+      );
+      expect(insertScriptCalls).toHaveLength(0);
+
+      // The final UPDATE should reference the existing script id
+      const updateCalls = (mockQuery.mock.calls as unknown as Array<[string, unknown[]]>).filter(
+        ([sql, params]) => typeof sql === 'string' && sql.includes('UPDATE dj_scripts') && Array.isArray(params) && params.includes(existingScriptId),
+      );
+      expect(updateCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('skips already-inserted segments and does not call LLM for them', async () => {
+      const existingScriptId = 'script-partial';
+      // Simulate 2 segments already done (show_intro at position 0, song_intro at position 1)
+      const existingSegments = [
+        { position: 0, script_text: 'Previously generated show intro' },
+        { position: 1, script_text: 'Previously generated song intro' },
+      ];
+
+      setupFreshRunMocks('unused', {
+        existingScript: existingScriptId,
+        existingSegments,
+      });
+
+      await runGenerationJob({
+        playlist_id: 'playlist-1',
+        station_id: 'station-1',
+        auto_approve: false,
+      });
+
+      // generatedTexts should have been pre-populated with existing text
+      // LLM should have been called only for segments after position 1
+      // For 1 playlist entry, segments are: show_intro(0), song_intro(1), opening station_id(2), show_outro(3)
+      // Positions 0 and 1 are already done, so LLM is only called for positions 2+ (station_id, show_outro)
+      expect(mockLlmComplete.mock.calls.length).toBeLessThanOrEqual(2);
+    });
+
+    it('pre-populates generatedTexts with already-done segment text for variety context', async () => {
+      const existingScriptId = 'script-context';
+      const existingSegments = [
+        { position: 0, script_text: 'Show intro text already done' },
+      ];
+
+      setupFreshRunMocks('unused', {
+        existingScript: existingScriptId,
+        existingSegments,
+      });
+
+      let capturedPrompt = '';
+      mockLlmComplete.mockImplementation(async (msgs: Array<{ role: string; content: string }>) => {
+        // Capture the user prompt to verify variety context was passed
+        capturedPrompt = msgs.find((m) => m.role === 'user')?.content ?? '';
+        return { text: 'Generated' };
+      });
+
+      await runGenerationJob({
+        playlist_id: 'playlist-1',
+        station_id: 'station-1',
+        auto_approve: false,
+      });
+
+      // The existing segment text should be reflected in the previousSegmentTexts context
+      // (it gets passed as part of the prompt for variety)
+      // At least verify LLM was called (for the remaining segments)
+      expect(mockLlmComplete).toHaveBeenCalled();
+    });
+  });
+
+  // ── AC5: Failed segments are logged ───────────────────────────────────────
+
+  describe('AC5 — failed segments are logged with error details', () => {
+    it('logs a detailed error message when an LLM call permanently fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockLlmComplete.mockRejectedValue(new Error('Request failed with status 429'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 'station-1', name: 'FM', timezone: 'UTC', company_id: 'co-1' }] })
+        .mockResolvedValueOnce({ rows: [{ key: 'llm_api_key', value: 'key' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 'p-1', llm_model: 'model', llm_temperature: 0.8, tts_voice_id: 'alloy' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 'e1', hour: 10, position: 0, song_title: 'S', song_artist: 'A', duration_sec: 180 }] })
+        .mockResolvedValueOnce({ rows: [] }) // templates
+        .mockResolvedValueOnce({ rows: [] }) // adlib clips
+        .mockResolvedValueOnce({ rows: [] }) // shoutouts
+        .mockResolvedValueOnce({ rows: [] }) // existing script check → no existing script
+        .mockResolvedValueOnce({ rows: [] }) // segments resume (always runs, null script_id → empty)
+        .mockResolvedValueOnce({ rows: [{ id: 'script-log-test' }] }) // INSERT new script
+        .mockResolvedValueOnce({ rows: [] }); // program themes
+
+      await expect(
+        runGenerationJob({ playlist_id: 'playlist-1', station_id: 'station-1', auto_approve: false }),
+      ).rejects.toThrow();
+
+      // Verify that error was logged with "permanently" and the segment type
+      const errorCalls = consoleSpy.mock.calls.map((c) => c.join(' '));
+      const hasDetailedLog = errorCalls.some(
+        (msg) => msg.includes('permanently') && msg.includes('provider=') && msg.includes('segment='),
+      );
+      expect(hasDetailedLog).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/services/station/src/queues/radioPipeline.ts
+++ b/services/station/src/queues/radioPipeline.ts
@@ -108,29 +108,77 @@ async function fetchServiceToken(): Promise<string> {
   return token;
 }
 
+// ── Stage column map ─────────────────────────────────────────────────────────
+
+/** Maps logical stage name → per-stage JSONB column (for Pipeline UI). */
+const STAGE_TO_COLUMN: Record<string, string> = {
+  generate_playlist: 'stage_playlist',
+  generate_script:   'stage_dj_script',
+  review:            'stage_review',
+  generate_tts:      'stage_tts',
+  publish:           'stage_publish',
+};
+
 // ── DB helpers ────────────────────────────────────────────────────────────────
 
 async function setStage(runId: string, stage: string): Promise<void> {
-  await getPool().query(
-    `UPDATE pipeline_runs SET current_stage = $1, status = 'running', updated_at = NOW()
-     WHERE id = $2`,
-    [stage, runId],
-  );
+  const col = STAGE_TO_COLUMN[stage];
+  if (col) {
+    await getPool().query(
+      `UPDATE pipeline_runs
+       SET current_stage = $1, status = 'running',
+           ${col} = jsonb_build_object('status', 'running', 'started_at', NOW()::text),
+           updated_at = NOW()
+       WHERE id = $2`,
+      [stage, runId],
+    );
+  } else {
+    await getPool().query(
+      `UPDATE pipeline_runs SET current_stage = $1, status = 'running', updated_at = NOW()
+       WHERE id = $2`,
+      [stage, runId],
+    );
+  }
 }
 
 async function completeStage(runId: string, stage: string, result: Record<string, unknown>): Promise<void> {
-  await getPool().query(
-    `UPDATE pipeline_runs
-     SET stages_completed = stages_completed || jsonb_build_object($1::text, $2::jsonb),
-         updated_at = NOW()
-     WHERE id = $3`,
-    [stage, JSON.stringify(result), runId],
-  );
+  const col = STAGE_TO_COLUMN[stage];
+  const status = result.skipped ? 'skipped' : 'completed';
+  const stageData = JSON.stringify({
+    status,
+    ...(status === 'completed' ? { completed_at: new Date().toISOString() } : {}),
+    ...result,
+  });
+  if (col) {
+    await getPool().query(
+      `UPDATE pipeline_runs
+       SET stages_completed = stages_completed || jsonb_build_object($1::text, $2::jsonb),
+           ${col} = $3::jsonb,
+           updated_at = NOW()
+       WHERE id = $4`,
+      [stage, JSON.stringify(result), stageData, runId],
+    );
+  } else {
+    await getPool().query(
+      `UPDATE pipeline_runs
+       SET stages_completed = stages_completed || jsonb_build_object($1::text, $2::jsonb),
+           updated_at = NOW()
+       WHERE id = $3`,
+      [stage, JSON.stringify(result), runId],
+    );
+  }
 }
 
 async function failRun(runId: string, message: string): Promise<void> {
+  // Also mark the currently-running stage column as failed
   await getPool().query(
-    `UPDATE pipeline_runs SET status = 'failed', error_message = $1, updated_at = NOW()
+    `UPDATE pipeline_runs
+     SET status = 'failed', error_message = $1,
+         stage_playlist  = CASE WHEN current_stage = 'generate_playlist' THEN stage_playlist  || jsonb_build_object('status','failed','error',$1,'completed_at',NOW()::text) ELSE stage_playlist  END,
+         stage_dj_script = CASE WHEN current_stage = 'generate_script'   THEN stage_dj_script || jsonb_build_object('status','failed','error',$1,'completed_at',NOW()::text) ELSE stage_dj_script END,
+         stage_tts       = CASE WHEN current_stage = 'generate_tts'      THEN stage_tts       || jsonb_build_object('status','failed','error',$1,'completed_at',NOW()::text) ELSE stage_tts       END,
+         stage_publish   = CASE WHEN current_stage = 'publish'           THEN stage_publish   || jsonb_build_object('status','failed','error',$1,'completed_at',NOW()::text) ELSE stage_publish   END,
+         updated_at = NOW()
      WHERE id = $2`,
     [message, runId],
   );
@@ -409,6 +457,10 @@ export function startRadioPipelineWorker(): Worker<RadioPipelineJobData> {
           segments_done: segRow ? parseInt(String(segRow.count), 10) : null,
           total_segments: segRow?.total_segments ?? null,
         });
+        // Mark review stage as skipped when auto-approved (manual review stays at default 'pending')
+        if (config.auto_approve) {
+          await completeStage(pipeline_run_id, 'review', { skipped: true });
+        }
       }
 
       // ── Stage 3: generate_tts ───────────────────────────────────────────────

--- a/services/station/src/routes/radioPipeline.ts
+++ b/services/station/src/routes/radioPipeline.ts
@@ -11,6 +11,12 @@ interface RunParams {
   runId: string;
 }
 
+interface RetryParams {
+  id: string;
+  runId: string;
+  stageName: string;
+}
+
 interface TriggerBody {
   date?: string;
   dj_profile_id?: string;
@@ -24,6 +30,18 @@ interface TriggerBody {
 interface ListQuery {
   limit?: number;
 }
+
+/** Ordered stage names — used for retry to determine which stages to clear. */
+const STAGE_ORDER = ['generate_playlist', 'generate_script', 'generate_tts', 'publish'] as const;
+type StageName = typeof STAGE_ORDER[number];
+
+/** Maps stage name to per-stage JSONB column name. */
+const STAGE_COLUMN: Record<StageName, string> = {
+  generate_playlist: 'stage_playlist',
+  generate_script: 'stage_dj_script',
+  generate_tts: 'stage_tts',
+  publish: 'stage_publish',
+};
 
 export default async function radioPipelineRoutes(app: FastifyInstance): Promise<void> {
   app.post<{ Params: StationParams; Body: TriggerBody }>(
@@ -93,20 +111,26 @@ export default async function radioPipelineRoutes(app: FastifyInstance): Promise
 
   app.get<{ Params: StationParams; Querystring: ListQuery }>(
     '/stations/:id/pipeline/runs',
-    async (req, reply) => {
+    async (req, _reply) => {
       const { id: station_id } = req.params;
       const limit = Math.min(req.query.limit ?? 10, 50);
       const pool = getPool();
 
-      const { rows } = await pool.query(
-        `SELECT * FROM pipeline_runs
-         WHERE station_id = $1
-         ORDER BY created_at DESC
-         LIMIT $2`,
-        [station_id, limit],
-      );
+      const [{ rows }, { rows: countRows }] = await Promise.all([
+        pool.query(
+          `SELECT * FROM pipeline_runs
+           WHERE station_id = $1
+           ORDER BY created_at DESC
+           LIMIT $2`,
+          [station_id, limit],
+        ),
+        pool.query<{ count: string }>(
+          `SELECT COUNT(*)::int AS count FROM pipeline_runs WHERE station_id = $1`,
+          [station_id],
+        ),
+      ]);
 
-      return rows;
+      return { runs: rows, total: Number(countRows[0]?.count ?? 0) };
     },
   );
 
@@ -123,6 +147,56 @@ export default async function radioPipelineRoutes(app: FastifyInstance): Promise
 
       if (!rows[0]) return reply.notFound('Pipeline run not found');
       return rows[0];
+    },
+  );
+
+  app.post<{ Params: RetryParams }>(
+    '/stations/:id/pipeline/runs/:runId/retry/:stageName',
+    async (req, reply) => {
+      const { id: station_id, runId, stageName } = req.params;
+
+      const stageIdx = STAGE_ORDER.indexOf(stageName as StageName);
+      if (stageIdx === -1) return reply.badRequest(`Unknown stage: ${stageName}`);
+
+      const pool = getPool();
+      const { rows } = await pool.query<{
+        id: string;
+        status: string;
+        stages_completed: Record<string, unknown>;
+      }>(
+        `SELECT id, status, stages_completed FROM pipeline_runs WHERE id = $1 AND station_id = $2`,
+        [runId, station_id],
+      );
+      const run = rows[0];
+      if (!run) return reply.notFound('Pipeline run not found');
+      if (run.status === 'running') return reply.conflict('Cannot retry a running pipeline');
+
+      // Clear the retried stage and all subsequent stages from stages_completed
+      const stagesToClear = STAGE_ORDER.slice(stageIdx);
+      const stagesCompleted = { ...(run.stages_completed as Record<string, unknown>) };
+      for (const s of stagesToClear) {
+        delete stagesCompleted[s];
+      }
+
+      // Build SET clause to reset per-stage columns back to pending
+      const stageCols = stagesToClear
+        .map((s) => `${STAGE_COLUMN[s]} = '{"status":"pending"}'::jsonb`)
+        .join(', ');
+
+      await pool.query(
+        `UPDATE pipeline_runs
+         SET status = 'queued', stages_completed = $1, ${stageCols}, updated_at = NOW()
+         WHERE id = $2`,
+        [JSON.stringify(stagesCompleted), runId],
+      );
+
+      const queue = getRadioPipelineQueue();
+      await queue.add('pipeline', { station_id, pipeline_run_id: runId }, {
+        jobId: `pipeline:${station_id}:${Date.now()}`,
+      });
+
+      reply.code(202);
+      return { pipeline_run_id: runId, stage: stageName, status: 'queued' };
     },
   );
 }

--- a/services/station/tests/unit/radioPipeline.test.ts
+++ b/services/station/tests/unit/radioPipeline.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for /stations/:id/pipeline/* routes
+ *
+ * Verifies:
+ * - GET /stations/:id/pipeline/runs returns { runs: [], total: N }
+ * - POST /stations/:id/pipeline/trigger returns pipeline_run_id + 202
+ * - POST /stations/:id/pipeline/runs/:runId/retry/:stageName re-queues the run
+ * - Retry rejects unknown stage names
+ * - Retry rejects a currently-running run
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import sensible from '@fastify/sensible';
+
+// ─── Module mocks ──────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock('../../src/db', () => ({
+  getPool: vi.fn(() => ({ query: mockQuery })),
+}));
+
+vi.mock('../../src/queues/radioPipeline', async () => {
+  const actual = await vi.importActual<typeof import('../../src/queues/radioPipeline')>(
+    '../../src/queues/radioPipeline',
+  );
+  return {
+    ...actual,
+    getRadioPipelineQueue: vi.fn(() => ({
+      add: vi.fn().mockResolvedValue({ id: 'bull-job-1' }),
+    })),
+  };
+});
+
+vi.mock('@playgen/middleware', () => ({
+  authenticate: vi.fn(async (req: Record<string, unknown>) => {
+    req.user = { sub: 'user-1', cid: 'company-1', rc: 'company_admin' };
+  }),
+  registerSecurity: vi.fn(),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false });
+  app.register(sensible);
+  const { default: radioPipelineRoutes } = await import('../../src/routes/radioPipeline');
+  app.register(radioPipelineRoutes, { prefix: '/api/v1' });
+  await app.ready();
+  return app;
+}
+
+const STATION_ID = 'station-uuid-1';
+const RUN_ID = 'run-uuid-1';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /stations/:id/pipeline/runs', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  it('returns { runs, total } shape', async () => {
+    const mockRun = {
+      id: RUN_ID,
+      station_id: STATION_ID,
+      date: '2026-05-03',
+      status: 'completed',
+      triggered_by: 'manual',
+      stage_playlist: { status: 'completed' },
+      stage_dj_script: { status: 'completed' },
+      stage_review: { status: 'skipped' },
+      stage_tts: { status: 'completed' },
+      stage_publish: { status: 'completed' },
+      created_at: '2026-05-03T10:00:00Z',
+      updated_at: '2026-05-03T10:05:00Z',
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [mockRun] })   // rows query
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] }); // count query
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty('runs');
+    expect(body).toHaveProperty('total');
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect(body.total).toBe(1);
+    expect(body.runs[0].id).toBe(RUN_ID);
+  });
+
+  it('respects limit query param (max 50)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs?limit=100`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    // The query should have been called with limit capped at 50
+    const firstCall = mockQuery.mock.calls[0];
+    expect(firstCall[1]).toContain(50);
+  });
+});
+
+describe('POST /stations/:id/pipeline/trigger', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  it('returns 202 with pipeline_run_id', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ timezone: 'Asia/Manila' }] })  // station lookup
+      .mockResolvedValueOnce({ rows: [] })                              // active run check
+      .mockResolvedValueOnce({ rows: [{ id: RUN_ID }] });              // insert run
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/trigger`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = res.json();
+    expect(body.pipeline_run_id).toBe(RUN_ID);
+    expect(body.status).toBe('queued');
+  });
+
+  it('returns 409 if a run is already active', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ timezone: 'Asia/Manila' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'existing-run-id' }] }); // active run found
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/trigger`,
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe('POST /stations/:id/pipeline/runs/:runId/retry/:stageName', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = await buildApp();
+  });
+
+  it('returns 400 for unknown stage name', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs/${RUN_ID}/retry/unknown_stage`,
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 if run not found', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs/${RUN_ID}/retry/generate_playlist`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 409 if run is currently running', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: RUN_ID, status: 'running', stages_completed: {} }],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs/${RUN_ID}/retry/generate_playlist`,
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it('clears the retried stage and downstream, re-queues the run', async () => {
+    const { getRadioPipelineQueue } = await import('../../src/queues/radioPipeline');
+    const mockAdd = vi.fn().mockResolvedValue({ id: 'new-bull-id' });
+    (getRadioPipelineQueue as ReturnType<typeof vi.fn>).mockReturnValue({ add: mockAdd });
+
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: RUN_ID,
+          status: 'failed',
+          stages_completed: { generate_playlist: { playlist_id: 'p1' } },
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // UPDATE
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/v1/stations/${STATION_ID}/pipeline/runs/${RUN_ID}/retry/generate_script`,
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = res.json();
+    expect(body.pipeline_run_id).toBe(RUN_ID);
+    expect(body.stage).toBe('generate_script');
+
+    // The UPDATE should have been called
+    const updateCall = mockQuery.mock.calls[1];
+    expect(updateCall[0]).toMatch(/UPDATE pipeline_runs/i);
+
+    // generate_playlist should be preserved; generate_script+ should be cleared
+    const stagesArg = JSON.parse(updateCall[1][0] as string);
+    expect(stagesArg).toHaveProperty('generate_playlist');
+    expect(stagesArg).not.toHaveProperty('generate_script');
+    expect(stagesArg).not.toHaveProperty('generate_tts');
+    expect(stagesArg).not.toHaveProperty('publish');
+
+    // Job was re-queued
+    expect(mockAdd).toHaveBeenCalledWith(
+      'pipeline',
+      expect.objectContaining({ station_id: STATION_ID, pipeline_run_id: RUN_ID }),
+      expect.any(Object),
+    );
+  });
+});

--- a/shared/db/src/migrations/075_pipeline_runs_add_stage_columns.sql
+++ b/shared/db/src/migrations/075_pipeline_runs_add_stage_columns.sql
@@ -1,0 +1,22 @@
+-- Migration 073: Add per-stage JSONB columns + triggered_by to pipeline_runs
+--
+-- Migration 068 used CREATE TABLE IF NOT EXISTS which was a no-op (067 already created
+-- the table with a different schema). This migration adds the missing per-stage columns
+-- so the frontend Pipeline UI can read granular stage status without reconstructing it
+-- from the generic stages_completed map.
+
+ALTER TABLE pipeline_runs
+  ADD COLUMN IF NOT EXISTS stage_playlist  JSONB NOT NULL DEFAULT '{"status":"pending"}'::jsonb,
+  ADD COLUMN IF NOT EXISTS stage_dj_script JSONB NOT NULL DEFAULT '{"status":"pending"}'::jsonb,
+  ADD COLUMN IF NOT EXISTS stage_review    JSONB NOT NULL DEFAULT '{"status":"pending"}'::jsonb,
+  ADD COLUMN IF NOT EXISTS stage_tts       JSONB NOT NULL DEFAULT '{"status":"pending"}'::jsonb,
+  ADD COLUMN IF NOT EXISTS stage_publish   JSONB NOT NULL DEFAULT '{"status":"pending"}'::jsonb,
+  ADD COLUMN IF NOT EXISTS triggered_by    VARCHAR(20) NOT NULL DEFAULT 'manual'
+                                           CHECK (triggered_by IN ('manual','cron','auto'));
+
+COMMENT ON COLUMN pipeline_runs.stage_playlist  IS 'Playlist generation stage: {status, started_at, completed_at, error, metadata}';
+COMMENT ON COLUMN pipeline_runs.stage_dj_script IS 'DJ script generation stage: {status, progress, step, started_at, completed_at, error, metadata}';
+COMMENT ON COLUMN pipeline_runs.stage_review    IS 'Manual script review stage: {status, started_at, completed_at, error}';
+COMMENT ON COLUMN pipeline_runs.stage_tts       IS 'TTS audio generation stage: {status, progress, started_at, completed_at, error, metadata}';
+COMMENT ON COLUMN pipeline_runs.stage_publish   IS 'Publish to CDN stage: {status, started_at, completed_at, error, metadata}';
+COMMENT ON COLUMN pipeline_runs.triggered_by    IS 'Who triggered this run: manual (user), cron (scheduler), auto (downstream event)';


### PR DESCRIPTION
## Summary

- **`withRetry` util** (`services/dj/src/utils/retry.ts`): exponential backoff on HTTP 429/5xx, 3 attempts, skips non-retryable errors (4xx except 429)
- **generationWorker**: wraps all LLM calls in `withRetry`; on BullMQ retry, finds existing incomplete script and skips already-inserted segment positions (checkpoint resume)
- **ttsService**: wraps TTS provider calls in `withRetry` for 429/5xx transients
- **radioPipeline (queue)**: writes per-stage JSONB columns (`stage_playlist`, `stage_dj_script`, `stage_review`, `stage_tts`, `stage_publish`) on every `setStage`/`completeStage`/`failRun`; persists `segments_done`/`total`/`tts_segments_done` progress counts into `stages_completed`
- **radioPipeline (routes)**: new `POST /stations/:id/pipeline/runs/:runId/retry/:stageName` — clears retried stage + downstream, resets JSONB columns to `pending`, re-queues BullMQ job
- **Migration 075**: adds 5 per-stage JSONB columns + `triggered_by` to `pipeline_runs`

## AC Coverage

- [x] LLM calls retry with exponential backoff on 429/5xx (max 3 retries per segment)
- [x] TTS calls retry with exponential backoff on 429/5xx (max 3 retries per segment)
- [x] DJ generation resumes from last completed segment on job retry (not from scratch)
- [x] `pipeline_runs.stages_completed` includes progress metadata (segments_done/total)
- [x] Failed segments are logged with error details, not silently swallowed
- [x] Pipeline status endpoint returns per-segment progress during generation/TTS stages

## Test plan

- [ ] `pnpm run test:unit` — 166 DJ + 71 station tests green
- [ ] `pnpm run typecheck && pnpm run lint` — no errors
- [ ] `pipelineRetryResume.test.ts` — AC1 retry, AC3 checkpoint, AC5 logging
- [ ] `radioPipeline.test.ts` — GET runs, POST trigger, POST retry (400/404/409/202)

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)