### PR TITLE
fix(library): bypass YouTube bot detection in yt-dlp audio sourcing (#465)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,14 @@ LOG_LEVEL=info
 # Feature flags (frontend) — set to "true" to enable, default off
 # NEXT_PUBLIC_FEATURE_UI_ADVANCED_PLAYLIST_CREATION=false
 
+# ─── yt-dlp audio sourcing (library service) ───────────────────────────────────
+# Optional: path to a Netscape-format cookies.txt file exported from a browser session.
+# Required when YouTube blocks server-IP downloads with "Sign in to confirm you're not a bot".
+# Mount the file into the container and set this to its container path.
+YT_DLP_COOKIES_FILE=
+# Optional: override the yt-dlp binary path (default: yt-dlp on PATH)
+YT_DLP_PATH=
+
 # ─── info-broker audio sourcing ────────────────────────────────────────────────
 # Railway internal: http://info-broker.railway.internal:8000  |  local: http://localhost:8000
 INFO_BROKER_URL=http://info-broker.railway.internal:8000

--- a/services/library/Dockerfile
+++ b/services/library/Dockerfile
@@ -20,6 +20,8 @@ RUN pnpm --filter @playgen/library-service build
 
 FROM node:25-alpine
 WORKDIR /app
+RUN apk add --no-cache python3 py3-pip ffmpeg && \
+    pip3 install --break-system-packages yt-dlp
 RUN npm install -g pnpm
 COPY --from=builder /app/pnpm-workspace.yaml ./
 COPY --from=builder /app/package.json ./

--- a/services/library/src/services/audioSourceService.ts
+++ b/services/library/src/services/audioSourceService.ts
@@ -10,6 +10,21 @@ const execFileAsync = promisify(execFile);
 
 const YT_DLP = process.env.YT_DLP_PATH || 'yt-dlp';
 
+/**
+ * Build yt-dlp args that bypass YouTube bot-detection on cloud/Railway IPs.
+ * iOS/Android player clients use YouTube's mobile API and are not subject to
+ * the bot-check pipeline that blocks requests from cloud server IPs.
+ * Exported for unit testing.
+ */
+export function buildYtDlpBotArgs(): string[] {
+  const args: string[] = ['--extractor-args', 'youtube:player_client=ios,android'];
+  const cookiesFile = process.env.YT_DLP_COOKIES_FILE;
+  if (cookiesFile) {
+    args.push('--cookies', cookiesFile);
+  }
+  return args;
+}
+
 interface SourceResult {
   songId: string;
   audioUrl: string;
@@ -42,6 +57,7 @@ export async function sourceFromYouTube(
       '--output', outputTemplate,
       '--no-warnings',
       '--quiet',
+      ...buildYtDlpBotArgs(),
     ], { timeout: 120_000 });
 
     // Find the downloaded file

--- a/services/library/tests/unit/audioSourceService.test.ts
+++ b/services/library/tests/unit/audioSourceService.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// execFile mock — captured per test so we can inspect yt-dlp args
+const mockExecFileAsync = vi.fn();
+
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
+
+// promisify: return our async mock when called with any fn
+vi.mock('util', () => ({
+  promisify: () => mockExecFileAsync,
+}));
+
+const mockQuery = vi.fn();
+vi.mock('../../src/db', () => ({ getPool: () => ({ query: mockQuery }) }));
+
+vi.mock('../../src/services/audioStorageService', () => ({
+  storeAudioFile: vi.fn().mockResolvedValue({ audioUrl: 'https://r2.example.com/s.mp3', durationSec: 210 }),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      promises: {
+        mkdtemp: vi.fn().mockResolvedValue('/tmp/playgen-ytdl-test'),
+        readdir: vi.fn().mockResolvedValue(['abc123.mp3']),
+        rm: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+    promises: {
+      mkdtemp: vi.fn().mockResolvedValue('/tmp/playgen-ytdl-test'),
+      readdir: vi.fn().mockResolvedValue(['abc123.mp3']),
+      rm: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+// ─── buildYtDlpBotArgs (pure — no I/O mocking needed) ────────────────────────
+
+describe('buildYtDlpBotArgs', () => {
+  beforeEach(() => {
+    delete process.env.YT_DLP_COOKIES_FILE;
+  });
+
+  it('always includes ios,android player clients', async () => {
+    const { buildYtDlpBotArgs } = await import('../../src/services/audioSourceService');
+    const args = buildYtDlpBotArgs();
+    const idx = args.indexOf('--extractor-args');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('youtube:player_client=ios,android');
+  });
+
+  it('omits --cookies when YT_DLP_COOKIES_FILE is unset', async () => {
+    const { buildYtDlpBotArgs } = await import('../../src/services/audioSourceService');
+    expect(buildYtDlpBotArgs()).not.toContain('--cookies');
+  });
+
+  it('includes --cookies <path> when YT_DLP_COOKIES_FILE is set', async () => {
+    process.env.YT_DLP_COOKIES_FILE = '/run/secrets/yt-cookies.txt';
+    const { buildYtDlpBotArgs } = await import('../../src/services/audioSourceService');
+    const args = buildYtDlpBotArgs();
+    const idx = args.indexOf('--cookies');
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe('/run/secrets/yt-cookies.txt');
+  });
+});
+
+// ─── sourceFromYouTube — integration with yt-dlp args ────────────────────────
+
+describe('sourceFromYouTube — yt-dlp argument construction', () => {
+  beforeEach(() => {
+    mockExecFileAsync.mockReset();
+    mockQuery.mockReset();
+    mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    mockQuery.mockResolvedValue({ rows: [] });
+    delete process.env.YT_DLP_COOKIES_FILE;
+    delete process.env.YT_DLP_PATH;
+  });
+
+  function capturedArgs(): string[] {
+    const call = mockExecFileAsync.mock.calls[0];
+    return call ? (call[1] as string[]) : [];
+  }
+
+  it('searches using "artist - title" format', async () => {
+    const { sourceFromYouTube } = await import('../../src/services/audioSourceService');
+    await sourceFromYouTube('song-1', 'station-1', 'Bohemian Rhapsody', 'Queen');
+
+    expect(capturedArgs()[0]).toBe('ytsearch1:Queen - Bohemian Rhapsody');
+  });
+
+  it('includes bot-detection bypass args from buildYtDlpBotArgs', async () => {
+    const { sourceFromYouTube, buildYtDlpBotArgs } = await import('../../src/services/audioSourceService');
+    await sourceFromYouTube('song-1', 'station-1', 'Test Song', 'Test Artist');
+
+    const args = capturedArgs();
+    for (const botArg of buildYtDlpBotArgs()) {
+      expect(args).toContain(botArg);
+    }
+  });
+});

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -31,7 +31,7 @@ _Updated: 2026-05-03 by PM agent_
 
 - [ ] feat(station+dj+frontend): Pipeline UI — GitHub Actions-style Radio Program Factory dashboard (#499, feat/issue-499) | @claude-sonnet-4-6 | 2026-05-03 | Migration: none (uses 075 from #529)
 - [x] fix(scheduler+station): inherit_library category remapping + station auto-creation slots (#497, #498, fix/issue-497-498) | @claude-sonnet-4-6 | 2026-05-03
-- [ ] fix(library): yt-dlp YouTube bot detection — cookie auth + ios/android player clients (#465, fix/issue-465) | @claude-sonnet-4-6 | 2026-05-03
+- [x] fix(library): yt-dlp YouTube bot detection — cookie auth + ios/android player clients (#465, fix/issue-465, PR #547) | @claude-sonnet-4-6 | 2026-05-03
 
 ## Recently Completed
 - [x] fix(dj+station): LLM/TTS backoff, checkpoint resume, pipeline progress (#529, fix/issue-529, PR #544) | @claude-sonnet-4-6 | 2026-05-03 | Migration: 075

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -31,6 +31,7 @@ _Updated: 2026-05-03 by PM agent_
 
 - [ ] feat(station+dj+frontend): Pipeline UI — GitHub Actions-style Radio Program Factory dashboard (#499, feat/issue-499) | @claude-sonnet-4-6 | 2026-05-03 | Migration: none (uses 075 from #529)
 - [x] fix(scheduler+station): inherit_library category remapping + station auto-creation slots (#497, #498, fix/issue-497-498) | @claude-sonnet-4-6 | 2026-05-03
+- [ ] fix(library): yt-dlp YouTube bot detection — cookie auth + ios/android player clients (#465, fix/issue-465) | @claude-sonnet-4-6 | 2026-05-03
 
 ## Recently Completed
 - [x] fix(dj+station): LLM/TTS backoff, checkpoint resume, pipeline progress (#529, fix/issue-529, PR #544) | @claude-sonnet-4-6 | 2026-05-03 | Migration: 075


### PR DESCRIPTION
## Summary

- **Root cause**: yt-dlp on Railway (cloud IP) gets blocked by YouTube — the default web player client triggers bot-check pipeline
- Use `ios,android` player clients (`--extractor-args youtube:player_client=ios,android`) to bypass the bot-check pipeline
- Add `YT_DLP_COOKIES_FILE` env var: when set, passes `--cookies <path>` for cookie-based auth fallback
- Install yt-dlp + ffmpeg in the library service Dockerfile runtime image
- Extract `buildYtDlpBotArgs()` helper (exported for unit testing)

## Test plan

- [x] 5 new unit tests: player client args, no-cookie path, cookie path, search format, bot-args integration — all pass
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:unit` — 54/54 library tests pass

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)