### PR TITLE
feat(station+types+dj+frontend): Station Spec blueprint + human-like DJ transition jitter (#495, #422)

### DIFF
--- a/frontend/src/app/stations/[id]/layout.tsx
+++ b/frontend/src/app/stations/[id]/layout.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { href: 'dj', label: 'DJ' },
   { href: 'pipeline', label: 'Pipeline' },
   { href: 'settings', label: 'Settings' },
+  { href: 'spec', label: 'Spec' },
 ];
 
 export default function StationLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/stations/[id]/spec/page.tsx
+++ b/frontend/src/app/stations/[id]/spec/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import { apiFetch } from '@/lib/api';
+
+export default function StationSpecPage() {
+  const params = useParams<{ id: string }>();
+  const stationId = params.id;
+
+  const [specYaml, setSpecYaml] = useState<string>('');
+  const [draft, setDraft] = useState<string>('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const fetchSpec = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL ?? ''}/api/v1/stations/${stationId}/spec`,
+        {
+          headers: {
+            Authorization: `Bearer ${
+              typeof window !== 'undefined'
+                ? sessionStorage.getItem('playgen_token') ?? ''
+                : ''
+            }`,
+          },
+        },
+      );
+      if (!res.ok) throw new Error(`Failed to load spec (${res.status})`);
+      const text = await res.text();
+      setSpecYaml(text);
+      setDraft(text);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [stationId]);
+
+  useEffect(() => {
+    fetchSpec();
+  }, [fetchSpec]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    setValidationError(null);
+    try {
+      await apiFetch(`/api/v1/stations/${stationId}/spec`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: draft,
+      });
+      setSpecYaml(draft);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes('VALIDATION_ERROR') || msg.includes('Invalid spec')) {
+        setValidationError(msg);
+      } else {
+        setError(msg);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExportJson = async () => {
+    try {
+      const data = await apiFetch<object>(`/api/v1/stations/${stationId}/spec?format=json`);
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `station-${stationId}-spec.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleExportYaml = () => {
+    const blob = new Blob([specYaml], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `station-${stationId}-spec.yaml`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const isDirty = draft !== specYaml;
+
+  return (
+    <div className="p-6 max-w-4xl">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-zinc-100">Station Spec</h2>
+        <p className="text-sm text-zinc-400 mt-1">
+          Declarative blueprint for this station — like CLAUDE.md but for stations. Edit the YAML
+          to change DJ personalities, script rules, and music guidelines. Changes take effect on
+          the next pipeline run.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="text-sm text-zinc-500">Loading spec…</div>
+      ) : error ? (
+        <div className="rounded-md bg-red-900/30 border border-red-700/50 p-4 text-sm text-red-300">
+          {error}
+        </div>
+      ) : (
+        <>
+          {/* Toolbar */}
+          <div className="flex items-center gap-2 mb-3">
+            <button
+              onClick={handleSave}
+              disabled={saving || !isDirty}
+              className="px-4 py-2 bg-violet-600 hover:bg-violet-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-md transition-colors"
+            >
+              {saving ? 'Applying…' : 'Apply Spec'}
+            </button>
+            <button
+              onClick={() => setDraft(specYaml)}
+              disabled={!isDirty}
+              className="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed text-zinc-200 text-sm rounded-md transition-colors"
+            >
+              Discard
+            </button>
+            <div className="flex-1" />
+            <button
+              onClick={handleExportYaml}
+              className="px-3 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-400 text-xs rounded-md transition-colors"
+            >
+              Export YAML
+            </button>
+            <button
+              onClick={handleExportJson}
+              className="px-3 py-2 bg-zinc-800 hover:bg-zinc-700 text-zinc-400 text-xs rounded-md transition-colors"
+            >
+              Export JSON
+            </button>
+          </div>
+
+          {/* Feedback banners */}
+          {success && (
+            <div className="mb-3 rounded-md bg-emerald-900/30 border border-emerald-700/50 p-3 text-sm text-emerald-300">
+              Spec applied successfully. Changes will take effect on the next pipeline run.
+            </div>
+          )}
+          {validationError && (
+            <div className="mb-3 rounded-md bg-amber-900/30 border border-amber-700/50 p-3 text-sm text-amber-300 font-mono">
+              {validationError}
+            </div>
+          )}
+
+          {/* Editor */}
+          <div className="relative">
+            <textarea
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setValidationError(null);
+              }}
+              spellCheck={false}
+              className="w-full h-[600px] rounded-md border border-zinc-700 bg-zinc-900 text-zinc-100 text-xs font-mono p-4 resize-y focus:outline-none focus:ring-1 focus:ring-violet-500 leading-relaxed"
+              placeholder="# Station Spec v1&#10;name: My Station&#10;callsign: MYFC&#10;..."
+            />
+            {isDirty && (
+              <span className="absolute top-3 right-3 text-[10px] text-amber-400 font-medium">
+                unsaved changes
+              </span>
+            )}
+          </div>
+
+          <p className="mt-3 text-xs text-zinc-500">
+            Accepts YAML or JSON. Only fields present in the spec are updated — omitted fields are
+            left unchanged. DJ personas and programs are upserted by name.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -427,6 +430,9 @@ importers:
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/jsonwebtoken':
         specifier: ^9.0.6
         version: 9.0.10
@@ -2045,6 +2051,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -6012,6 +6021,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/services/dj/src/lib/promptBuilder.ts
+++ b/services/dj/src/lib/promptBuilder.ts
@@ -228,10 +228,44 @@ No phonetic respellings needed — the TTS engine handles Filipino pronunciation
 // control chars / bidi codepoints / zero-width unicode. Free-form text is
 // further wrapped in <untrusted> delimiters so prompt-injection payloads are
 // treated by the LLM as character data, not directives.
+/**
+ * Build a compact spec-rules block from station spec script_rules and library guidelines.
+ * Returns null when no spec data is available.
+ */
+export function buildSpecRulesSection(
+  scriptRules?: { language?: string; tone?: string; segment_length?: string; avoid?: string[]; always?: string[] } | null,
+  library?: { rules?: string[] } | null,
+): string | null {
+  const parts: string[] = [];
+
+  if (scriptRules) {
+    if (scriptRules.language) parts.push(`Script language/style: ${s(scriptRules.language, 300)}`);
+    if (scriptRules.tone) parts.push(`Tone: ${s(scriptRules.tone, 200)}`);
+    if (scriptRules.segment_length) parts.push(`Target segment length: ${s(scriptRules.segment_length, 100)}`);
+    if (scriptRules.always?.length) {
+      const safe = scriptRules.always.map((r) => `  - ${s(r, 200)}`).join('\n');
+      parts.push(`Always:\n${safe}`);
+    }
+    if (scriptRules.avoid?.length) {
+      const safe = scriptRules.avoid.map((r) => `  - ${s(r, 200)}`).join('\n');
+      parts.push(`Never:\n${safe}`);
+    }
+  }
+
+  if (library?.rules?.length) {
+    const safe = library.rules.map((r) => `  - ${s(r, 200)}`).join('\n');
+    parts.push(`Music guidelines:\n${safe}`);
+  }
+
+  if (!parts.length) return null;
+  return `Station-specific guidelines (follow these for every segment):\n${parts.join('\n')}`;
+}
+
 export function buildSystemPrompt(
   profile: DjProfile,
   localeCode?: string | null,
   ttsProvider?: string | null,
+  specRules?: string | null,
 ): string {
   const safeName = s(profile.name, LIMITS.name);
   const lines: string[] = [
@@ -263,6 +297,11 @@ export function buildSystemPrompt(
       lines.push('');
       lines.push(ttsGuide);
     }
+  }
+
+  if (specRules) {
+    lines.push('');
+    lines.push(specRules);
   }
 
   lines.push('');
@@ -365,8 +404,9 @@ export function buildMultiDjSystemPrompt(
   profiles: DjProfile[],
   localeCode?: string | null,
   ttsProvider?: string | null,
+  specRules?: string | null,
 ): string {
-  if (profiles.length < 2) return buildSystemPrompt(profiles[0]!, localeCode, ttsProvider);
+  if (profiles.length < 2) return buildSystemPrompt(profiles[0]!, localeCode, ttsProvider, specRules);
 
   const names = profiles.map((p) => s(p.name, LIMITS.name));
   const nameList = names.join(', ');
@@ -399,6 +439,11 @@ export function buildMultiDjSystemPrompt(
       lines.push('');
       lines.push(ttsGuide);
     }
+  }
+
+  if (specRules) {
+    lines.push('');
+    lines.push(specRules);
   }
 
   const tagLines = names.map((n) => `[${n}] Spoken text here...`).join('\n');

--- a/services/dj/src/workers/generationWorker.ts
+++ b/services/dj/src/workers/generationWorker.ts
@@ -2,8 +2,9 @@ import { getPool } from '../db.js';
 import { getSocialProviders } from '../adapters/social/index.js';
 import { llmComplete } from '../adapters/llm/index.js';
 import { withRetry } from '../utils/retry.js';
-import { buildSystemPrompt, buildDualDjSystemPrompt, buildMultiDjSystemPrompt, buildUserPrompt } from '../lib/promptBuilder.js';
+import { buildSystemPrompt, buildDualDjSystemPrompt, buildMultiDjSystemPrompt, buildUserPrompt, buildSpecRulesSection } from '../lib/promptBuilder.js';
 import type { StationIdentity } from '../lib/promptBuilder.js';
+import type { StationSpec } from '@playgen/types';
 import { logLlmUsage } from '../lib/usageLogger.js';
 import { checkLlmRateLimit } from '../lib/rateLimiter.js';
 import { getInfoBrokerClient } from '../lib/infoBroker.js';
@@ -51,6 +52,8 @@ interface StationRow {
   frequency: string | null;
   news_scope: string | null;
   news_topic: string | null;
+  // Declarative station blueprint (migration 076)
+  station_spec: StationSpec | null;
 }
 
 /**
@@ -148,7 +151,7 @@ export async function runGenerationJob(
     `SELECT id, name, timezone, locale_code, company_id,
             city, country_code, latitude, longitude,
             callsign, tagline, frequency,
-            news_scope, news_topic
+            news_scope, news_topic, station_spec
      FROM stations WHERE id = $1`,
     [data.station_id],
   );
@@ -161,6 +164,11 @@ export async function runGenerationJob(
     frequency: station.frequency,
     city: station.city,
   };
+
+  // Build spec-rules string from station_spec (migration 076) — injected into every system prompt.
+  const specRules = station.station_spec
+    ? buildSpecRulesSection(station.station_spec.script_rules, station.station_spec.library)
+    : null;
 
   // 1b. Load per-station settings (API key overrides, model, TTS provider, etc.)
   const stationSettings = await loadStationSettings(data.station_id);
@@ -531,8 +539,8 @@ export async function runGenerationJob(
         : undefined,
     };
     const systemPrompt = isDualDj
-      ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider)
-      : buildSystemPrompt(profile!, station.locale_code, effectiveTtsProvider);
+      ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider, specRules)
+      : buildSystemPrompt(profile!, station.locale_code, effectiveTtsProvider, specRules);
     const userPrompt = buildUserPrompt(ctx) + rejectionContext;
 
     // Resume checkpoint: skip if this position was already inserted in a previous attempt
@@ -748,8 +756,8 @@ export async function runGenerationJob(
       };
 
       const systemPrompt = isDualDj
-        ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider)
-        : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider);
+        ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider, specRules)
+        : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider, specRules);
       const userPrompt = buildUserPrompt(ctx) + rejectionContext;
 
       console.info(
@@ -859,8 +867,8 @@ export async function runGenerationJob(
           };
 
           const shoutoutSystemPrompt = isDualDj
-            ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider)
-            : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider);
+            ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider, specRules)
+            : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider, specRules);
           const shoutoutUserPrompt = buildUserPrompt(shoutoutCtx) + (data.rejection_notes
             ? `\n\nIMPORTANT: The previous script was rejected by the reviewer. Their feedback: "${data.rejection_notes}". Please rewrite accordingly.`
             : '');
@@ -1036,9 +1044,13 @@ async function injectFloatingSegments(opts: FloatingSegmentOpts): Promise<void> 
   );
   const sponsorName = settingRows[0]?.value ?? null;
 
+  const floatingSpecRules = station.station_spec
+    ? buildSpecRulesSection(station.station_spec.script_rules, station.station_spec.library)
+    : null;
+
   const systemPrompt = isDualDj
-    ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider)
-    : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider);
+    ? buildMultiDjSystemPrompt(allProfiles, station.locale_code, effectiveTtsProvider, floatingSpecRules)
+    : buildSystemPrompt(profile, station.locale_code, effectiveTtsProvider, floatingSpecRules);
 
   let injected = 0;
 

--- a/services/station/package.json
+++ b/services/station/package.json
@@ -23,10 +23,12 @@
     "jsonwebtoken": "^9.0.2",
     "openai": "^6.34.0",
     "pg": "^8.11.0",
+    "js-yaml": "^4.1.0",
     "unzipper": "^0.12.3"
   },
   "devDependencies": {
     "@types/archiver": "^7.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/bcrypt": "^6.0.0",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^25.6.0",

--- a/services/station/src/index.ts
+++ b/services/station/src/index.ts
@@ -20,6 +20,7 @@ import { startPublishWorker } from './queues/publishPipeline';
 import { startRadioPipelineWorker } from './queues/radioPipeline';
 import { programExportRoutes } from './routes/programExport';
 import { programImportRoutes } from './routes/programImport';
+import { specRoutes } from './routes/specRoutes';
 
 const app = Fastify({
   logger: {
@@ -51,6 +52,7 @@ app.register(publicStationRoutes,  { prefix: '/api/v1' });
 app.register(radioPipelineRoutes,  { prefix: '/api/v1' });
 app.register(programExportRoutes,  { prefix: '/api/v1' });
 app.register(programImportRoutes,  { prefix: '/api/v1' });
+app.register(specRoutes,           { prefix: '/api/v1' });
 
 app.setErrorHandler((err: FastifyError, _req, reply) => {
   app.log.error(err);

--- a/services/station/src/queues/hlsBuilder.ts
+++ b/services/station/src/queues/hlsBuilder.ts
@@ -41,8 +41,26 @@ export function buildEntryCumulativeMap(entries: SongEntry[]): Map<string, numbe
 }
 
 /**
+ * Deterministic pseudo-random float in [min, max) seeded by a string.
+ * Uses FNV-1a hash so the same segment always receives the same jitter,
+ * making HLS rebuilds (e.g. on publish retry) produce identical output.
+ */
+function seededJitter(seed: string, min: number, max: number): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return min + ((h % 10000) / 10000) * (max - min);
+}
+
+/**
  * Resolve all DJ segments to absolute program-timeline clips.
  * Skips segments without audio or unresolvable anchors.
+ *
+ * song_transition sequential segments receive a seeded jitter of -1.5 to +2.0 s
+ * so the DJ doesn't always cut in at the exact song boundary — emulating the
+ * natural dead-air pauses and early cut-ins heard on live radio (Issue #422).
  */
 export function resolveDjClips(
   allSegs: DjSegmentRow[],
@@ -64,10 +82,15 @@ export function resolveDjClips(
       if (songStartSec == null) continue;
       offsetSec = songStartSec + parseFloat(String(seg.start_offset_sec));
     } else if (seg.playlist_entry_id != null) {
-      // Sequential segment: offset = associated entry's start in music timeline
+      // Sequential segment: offset = associated entry's start in music timeline.
+      // song_transition segments get seeded jitter (-1.5 s to +2.0 s) to
+      // simulate natural dead-air gaps and early DJ cut-ins (Issue #422).
       const songStartSec = entryCumulativeSec.get(seg.playlist_entry_id);
       if (songStartSec == null) continue;
-      offsetSec = songStartSec;
+      const jitter = seg.segment_type === 'song_transition'
+        ? seededJitter(seg.id, -1.5, 2.0)
+        : 0;
+      offsetSec = songStartSec + jitter;
     } else {
       // Unanchored: show_outro at end, everything else at 0
       offsetSec = seg.segment_type === 'show_outro'

--- a/services/station/src/routes/specRoutes.ts
+++ b/services/station/src/routes/specRoutes.ts
@@ -1,0 +1,95 @@
+/**
+ * specRoutes — Station Spec API endpoints.
+ *
+ * GET  /api/v1/stations/:id/spec         — export spec (JSON or YAML)
+ * PUT  /api/v1/stations/:id/spec         — apply spec to existing station
+ * POST /api/v1/companies/:id/stations/from-spec — bootstrap new station from spec
+ */
+import type { FastifyInstance } from 'fastify';
+import { authenticate, requirePermission, requireStationAccess } from '@playgen/middleware';
+import { exportSpec, applySpec, bootstrapFromSpec, parseSpec, serializeSpecToYaml } from '../services/specService';
+
+export async function specRoutes(app: FastifyInstance) {
+  app.addHook('onRequest', authenticate);
+
+  /**
+   * GET /api/v1/stations/:id/spec
+   * Export the current station configuration as a StationSpec.
+   * Accepts ?format=yaml (default) or ?format=json via query param.
+   */
+  app.get('/stations/:id/spec', {
+    onRequest: [requirePermission('station:read'), requireStationAccess()],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { format = 'yaml' } = req.query as { format?: string };
+
+    const spec = await exportSpec(id);
+    if (!spec) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Station not found' } });
+
+    if (format === 'json') {
+      return reply.code(200).send(spec);
+    }
+
+    reply.header('Content-Type', 'text/plain; charset=utf-8');
+    return reply.code(200).send(serializeSpecToYaml(spec));
+  });
+
+  /**
+   * PUT /api/v1/stations/:id/spec
+   * Apply a StationSpec to an existing station.
+   * Body: raw YAML or JSON string, or a JSON object.
+   * Returns the updated station row.
+   */
+  app.put('/stations/:id/spec', {
+    onRequest: [requirePermission('station:write'), requireStationAccess()],
+  }, async (req, reply) => {
+    const { id } = req.params as { id: string };
+
+    let spec;
+    try {
+      if (typeof req.body === 'string') {
+        spec = parseSpec(req.body);
+      } else if (typeof req.body === 'object' && req.body !== null) {
+        // Already parsed JSON from Fastify
+        spec = req.body;
+      } else {
+        return reply.code(400).send({ error: { code: 'VALIDATION_ERROR', message: 'Body must be a YAML or JSON spec' } });
+      }
+    } catch (err) {
+      return reply.code(400).send({ error: { code: 'VALIDATION_ERROR', message: `Invalid spec: ${(err as Error).message}` } });
+    }
+
+    const station = await applySpec(id, spec);
+    if (!station) return reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'Station not found' } });
+
+    return reply.code(200).send(station);
+  });
+
+  /**
+   * POST /api/v1/companies/:id/stations/from-spec
+   * Create a brand-new station from a StationSpec.
+   * Body: raw YAML or JSON string, or a JSON object.
+   * Returns the newly created station row.
+   */
+  app.post('/companies/:id/stations/from-spec', {
+    onRequest: [requirePermission('station:create')],
+  }, async (req, reply) => {
+    const { id: companyId } = req.params as { id: string };
+
+    let spec;
+    try {
+      if (typeof req.body === 'string') {
+        spec = parseSpec(req.body);
+      } else if (typeof req.body === 'object' && req.body !== null) {
+        spec = req.body;
+      } else {
+        return reply.code(400).send({ error: { code: 'VALIDATION_ERROR', message: 'Body must be a YAML or JSON spec' } });
+      }
+    } catch (err) {
+      return reply.code(400).send({ error: { code: 'VALIDATION_ERROR', message: `Invalid spec: ${(err as Error).message}` } });
+    }
+
+    const station = await bootstrapFromSpec(companyId, spec);
+    return reply.code(201).send(station);
+  });
+}

--- a/services/station/src/services/specService.ts
+++ b/services/station/src/services/specService.ts
@@ -1,0 +1,368 @@
+/**
+ * specService — export, apply, and bootstrap stations from a StationSpec.
+ *
+ * A StationSpec is a declarative blueprint for a station: identity, DJ personas,
+ * programs, TTS config, and script rules. Partial specs are valid — only the
+ * fields present are applied; everything else is left unchanged.
+ */
+import yaml from 'js-yaml';
+import { getPool } from '../db';
+import type { StationSpec, SpecDj, SpecProgram, Station } from '@playgen/types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Parse a raw string as YAML or JSON into a StationSpec. Throws on parse error. */
+export function parseSpec(raw: string): StationSpec {
+  // js-yaml parses both YAML and JSON (JSON is valid YAML)
+  const parsed = yaml.load(raw);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Spec must be a YAML/JSON object');
+  }
+  return parsed as StationSpec;
+}
+
+/** Serialise a StationSpec to YAML string. */
+export function serializeSpecToYaml(spec: StationSpec): string {
+  return yaml.dump(spec, { lineWidth: 120, noRefs: true });
+}
+
+// ─── Export ────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a StationSpec from the current station database state.
+ * Reads: stations row + dj_profiles + programs + station_settings (non-secret).
+ */
+export async function exportSpec(stationId: string): Promise<StationSpec | null> {
+  const pool = getPool();
+
+  const { rows: stRows } = await pool.query<Station>(
+    `SELECT * FROM stations WHERE id = $1`,
+    [stationId],
+  );
+  const station = stRows[0];
+  if (!station) return null;
+
+  // Load non-secret station settings (TTS/LLM provider + voice)
+  const { rows: settingRows } = await pool.query<{ key: string; value: string }>(
+    `SELECT key, value FROM station_settings WHERE station_id = $1 AND is_secret = false`,
+    [stationId],
+  );
+  const settings = Object.fromEntries(settingRows.map((r) => [r.key, r.value]));
+
+  // Load DJ profiles
+  const { rows: djRows } = await pool.query<{
+    name: string;
+    personality: string | null;
+    voice_style: string | null;
+    tts_provider: string | null;
+    tts_voice_id: string | null;
+    is_default: boolean;
+    persona_config: Record<string, unknown> | null;
+  }>(
+    `SELECT name, personality, voice_style, tts_provider, tts_voice_id, is_default, persona_config
+     FROM dj_profiles WHERE company_id = (SELECT company_id FROM stations WHERE id = $1) AND is_active = true
+     ORDER BY is_default DESC, name`,
+    [stationId],
+  );
+
+  // Load programs
+  const { rows: progRows } = await pool.query<{
+    name: string;
+    start_hour: number;
+    end_hour: number;
+    active_days: string[];
+    themes: unknown;
+  }>(
+    `SELECT name, start_hour, end_hour, active_days, themes FROM programs WHERE station_id = $1 AND is_active = true ORDER BY start_hour`,
+    [stationId],
+  );
+
+  const djs: SpecDj[] = djRows.map((dj, idx) => {
+    const pc = dj.persona_config ?? {};
+    const entry: SpecDj = {
+      name: dj.name,
+      role: idx === 0 ? 'primary' : 'co-host',
+    };
+    if (dj.tts_provider || dj.tts_voice_id) {
+      entry.voice = {
+        provider: dj.tts_provider ?? 'openai',
+        voice_id: dj.tts_voice_id ?? 'alloy',
+      };
+    }
+    if (dj.personality) entry.personality = dj.personality;
+    if (typeof pc.energy_level === 'number') entry.energy = pc.energy_level;
+    if (typeof pc.humor_level === 'number') entry.humor = pc.humor_level;
+    if (typeof pc.formality === 'string') entry.formality = pc.formality as SpecDj['formality'];
+    if (Array.isArray(pc.catchphrases) && pc.catchphrases.length) entry.catchphrases = pc.catchphrases as string[];
+    if (typeof pc.signature_greeting === 'string') entry.greeting = pc.signature_greeting;
+    if (typeof pc.signature_signoff === 'string') entry.signoff = pc.signature_signoff;
+    if (typeof pc.backstory === 'string') entry.backstory = pc.backstory;
+    return entry;
+  });
+
+  const spec: StationSpec = {
+    version: '1',
+    name: station.name,
+    timezone: station.timezone,
+    broadcast: {
+      start_hour: station.broadcast_start_hour,
+      end_hour: station.broadcast_end_hour,
+      active_days: station.active_days,
+    },
+  };
+
+  if (station.callsign) spec.callsign = station.callsign;
+  if (station.tagline) spec.tagline = station.tagline;
+  if (station.frequency) spec.frequency = station.frequency;
+  if (station.broadcast_type) spec.broadcast_type = station.broadcast_type;
+  if (station.city) spec.city = station.city;
+  if (station.locale_code) spec.locale = station.locale_code;
+
+  if (settings['tts_provider'] || settings['tts_voice_id']) {
+    spec.tts = {
+      provider: settings['tts_provider'],
+      default_voice: settings['tts_voice_id'],
+    };
+  }
+
+  if (djs.length) spec.djs = djs;
+
+  if (progRows.length) {
+    spec.programs = progRows.map((p) => ({
+      name: p.name,
+      start_hour: p.start_hour,
+      end_hour: p.end_hour,
+      active_days: p.active_days,
+      ...(Array.isArray(p.themes) && p.themes.length ? { themes: p.themes as StationSpec['programs'] extends (infer T)[] ? T extends { themes?: infer TH } ? NonNullable<TH> : never[] : never[] } : {}),
+    }));
+  }
+
+  // Include stored spec rules if any (from a previous apply)
+  if (station.station_spec?.script_rules) {
+    spec.script_rules = station.station_spec.script_rules;
+  }
+  if (station.station_spec?.library) {
+    spec.library = station.station_spec.library;
+  }
+  if (station.station_spec?.dj_interaction) {
+    spec.dj_interaction = station.station_spec.dj_interaction;
+  }
+
+  return spec;
+}
+
+// ─── Apply ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply a StationSpec to an existing station.
+ * Non-destructive — only fields present in the spec are updated.
+ * Returns the updated station row.
+ */
+export async function applySpec(stationId: string, spec: StationSpec): Promise<Station | null> {
+  const pool = getPool();
+
+  // 1. Update core station fields
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  let i = 1;
+
+  const addField = (col: string, val: unknown) => {
+    if (val !== undefined) { fields.push(`${col} = $${i++}`); values.push(val); }
+  };
+
+  addField('name', spec.name);
+  addField('timezone', spec.timezone);
+  addField('callsign', spec.callsign);
+  addField('tagline', spec.tagline);
+  addField('frequency', spec.frequency);
+  addField('broadcast_type', spec.broadcast_type);
+  addField('city', spec.city);
+  addField('locale_code', spec.locale);
+  if (spec.broadcast?.start_hour !== undefined) addField('broadcast_start_hour', spec.broadcast.start_hour);
+  if (spec.broadcast?.end_hour !== undefined) addField('broadcast_end_hour', spec.broadcast.end_hour);
+  if (spec.broadcast?.active_days !== undefined) addField('active_days', spec.broadcast.active_days);
+
+  // Store the full spec as JSONB for pipeline use
+  addField('station_spec', JSON.stringify(spec));
+
+  if (fields.length) {
+    fields.push('updated_at = NOW()');
+    values.push(stationId);
+    await pool.query(
+      `UPDATE stations SET ${fields.join(', ')} WHERE id = $${i}`,
+      values,
+    );
+  }
+
+  // 2. Apply TTS settings (provider + default voice — non-secret)
+  if (spec.tts?.provider) {
+    await pool.query(
+      `INSERT INTO station_settings (station_id, key, value, is_secret)
+       VALUES ($1, 'tts_provider', $2, false)
+       ON CONFLICT (station_id, key) DO UPDATE SET value = EXCLUDED.value`,
+      [stationId, spec.tts.provider],
+    );
+  }
+  if (spec.tts?.default_voice) {
+    await pool.query(
+      `INSERT INTO station_settings (station_id, key, value, is_secret)
+       VALUES ($1, 'tts_voice_id', $2, false)
+       ON CONFLICT (station_id, key) DO UPDATE SET value = EXCLUDED.value`,
+      [stationId, spec.tts.default_voice],
+    );
+  }
+
+  // 3. Apply DJ personas (upsert by name within company)
+  if (spec.djs?.length) {
+    const { rows: companyRows } = await pool.query<{ company_id: string }>(
+      `SELECT company_id FROM stations WHERE id = $1`,
+      [stationId],
+    );
+    const companyId = companyRows[0]?.company_id;
+    if (companyId) {
+      for (let idx = 0; idx < spec.djs.length; idx++) {
+        await upsertDjFromSpec(companyId, spec.djs[idx], idx === 0);
+      }
+    }
+  }
+
+  // 4. Apply programs (upsert by name within station)
+  if (spec.programs?.length) {
+    for (const prog of spec.programs) {
+      const [startHour, endHour] = resolveHours(prog);
+      await pool.query(
+        `INSERT INTO programs (station_id, name, start_hour, end_hour, active_days, is_active, is_default)
+         VALUES ($1, $2, $3, $4, $5, true, false)
+         ON CONFLICT (station_id, name) DO UPDATE
+           SET start_hour = EXCLUDED.start_hour,
+               end_hour = EXCLUDED.end_hour,
+               active_days = EXCLUDED.active_days,
+               updated_at = NOW()`,
+        [stationId, prog.name, startHour, endHour, prog.active_days ?? ['MON','TUE','WED','THU','FRI','SAT','SUN']],
+      );
+    }
+  }
+
+  const { rows } = await pool.query<Station>(
+    `SELECT * FROM stations WHERE id = $1`,
+    [stationId],
+  );
+  return rows[0] ?? null;
+}
+
+// ─── Bootstrap ─────────────────────────────────────────────────────────────────
+
+/**
+ * Create a brand-new station from a StationSpec.
+ * Reuses the existing createStation flow then applies the spec on top.
+ */
+export async function bootstrapFromSpec(companyId: string, spec: StationSpec): Promise<Station> {
+  const pool = getPool();
+
+  const name = spec.name ?? 'New Station';
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+  const { rows } = await pool.query<Station>(
+    `INSERT INTO stations
+       (company_id, name, slug, timezone, broadcast_start_hour, broadcast_end_hour, active_days,
+        callsign, tagline, frequency, broadcast_type, city, locale_code, station_spec)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14::jsonb)
+     RETURNING *`,
+    [
+      companyId,
+      name,
+      slug,
+      spec.timezone ?? 'Asia/Manila',
+      spec.broadcast?.start_hour ?? 4,
+      spec.broadcast?.end_hour ?? 3,
+      spec.broadcast?.active_days ?? ['MON','TUE','WED','THU','FRI','SAT','SUN'],
+      spec.callsign ?? null,
+      spec.tagline ?? null,
+      spec.frequency ?? null,
+      spec.broadcast_type ?? null,
+      spec.city ?? null,
+      spec.locale ?? null,
+      JSON.stringify(spec),
+    ],
+  );
+  const station = rows[0];
+
+  // Seed rotation rules
+  await pool.query(
+    `INSERT INTO rotation_rules (station_id) VALUES ($1) ON CONFLICT DO NOTHING`,
+    [station.id],
+  );
+
+  // Fire-and-forget: seed default DJ + defaults, then apply spec on top
+  const { seedDefaultDjProfileForStation } = await import('./djSetupService');
+  seedDefaultDjProfileForStation(companyId, station.id).catch((err) => {
+    console.error('[spec] Failed to seed default DJ profile:', err);
+  });
+
+  // Apply DJ personas, programs, settings from spec (after a short delay for defaults to settle)
+  // We call applySpec but skip the identity fields (already set above)
+  setImmediate(async () => {
+    try {
+      const specWithoutIdentity: StationSpec = {
+        tts: spec.tts,
+        djs: spec.djs,
+        programs: spec.programs,
+      };
+      await applySpec(station.id, specWithoutIdentity);
+    } catch (err) {
+      console.error('[spec] Failed to apply spec on bootstrap:', err);
+    }
+  });
+
+  return station;
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────────────
+
+async function upsertDjFromSpec(companyId: string, dj: SpecDj, makeDefault: boolean): Promise<void> {
+  const pool = getPool();
+  const personaConfig = {
+    ...(dj.energy !== undefined ? { energy_level: dj.energy } : {}),
+    ...(dj.humor !== undefined ? { humor_level: dj.humor } : {}),
+    ...(dj.formality ? { formality: dj.formality } : {}),
+    ...(dj.catchphrases?.length ? { catchphrases: dj.catchphrases } : {}),
+    ...(dj.greeting ? { signature_greeting: dj.greeting } : {}),
+    ...(dj.signoff ? { signature_signoff: dj.signoff } : {}),
+    ...(dj.backstory ? { backstory: dj.backstory } : {}),
+  };
+
+  await pool.query(
+    `INSERT INTO dj_profiles
+       (company_id, name, personality, voice_style, tts_provider, tts_voice_id, persona_config, is_default, is_active)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8,true)
+     ON CONFLICT (company_id, name) DO UPDATE
+       SET personality   = COALESCE(EXCLUDED.personality, dj_profiles.personality),
+           voice_style   = COALESCE(EXCLUDED.voice_style, dj_profiles.voice_style),
+           tts_provider  = COALESCE(EXCLUDED.tts_provider, dj_profiles.tts_provider),
+           tts_voice_id  = COALESCE(EXCLUDED.tts_voice_id, dj_profiles.tts_voice_id),
+           persona_config= COALESCE(EXCLUDED.persona_config, dj_profiles.persona_config),
+           updated_at    = NOW()`,
+    [
+      companyId,
+      dj.name,
+      dj.personality ?? null,
+      null,
+      dj.voice?.provider ?? null,
+      dj.voice?.voice_id ?? null,
+      Object.keys(personaConfig).length ? JSON.stringify(personaConfig) : null,
+      makeDefault,
+    ],
+  );
+}
+
+/** Resolve start/end hours from a SpecProgram, handling "5-12" shorthand. */
+function resolveHours(prog: SpecProgram): [number, number] {
+  if (typeof prog.start_hour === 'number' && typeof prog.end_hour === 'number') {
+    return [prog.start_hour, prog.end_hour];
+  }
+  if (prog.hours) {
+    const match = prog.hours.match(/^(\d+)-(\d+)$/);
+    if (match) return [parseInt(match[1], 10), parseInt(match[2], 10)];
+  }
+  return [0, 23];
+}

--- a/services/station/tests/unit/hlsBuilder.test.ts
+++ b/services/station/tests/unit/hlsBuilder.test.ts
@@ -156,10 +156,57 @@ describe('resolveDjClips', () => {
     expect(clips[0].audioUrl).toBe('https://cdn/dj/float.mp3');
   });
 
-  it('resolves sequential segment to its entry start_sec', () => {
+  it('resolves sequential song_intro to its exact entry start_sec (no jitter)', () => {
     const clips = resolveDjClips([sequentialIntro], cumulativeMap, totalDuration);
     expect(clips).toHaveLength(1);
-    expect(clips[0].offsetSec).toBe(380); // song4 starts at 380
+    expect(clips[0].offsetSec).toBe(380); // song4 starts at 380, no jitter for song_intro
+  });
+
+  it('applies seeded jitter (-1.5 to +2.0 s) to sequential song_transition segments', () => {
+    const transition: DjSegmentRow = {
+      id: 'seg-trans-1',
+      segment_type: 'song_transition',
+      audio_url: 'https://cdn/dj/trans.mp3',
+      audio_duration_sec: 6,
+      playlist_entry_id: 'e2', // song2 starts at 200s
+      anchor_playlist_entry_id: null,
+      start_offset_sec: null,
+    };
+    const clips = resolveDjClips([transition], cumulativeMap, totalDuration);
+    expect(clips).toHaveLength(1);
+    // Jitter range: 200 + [-1.5, +2.0] → [198.5, 202.0]
+    expect(clips[0].offsetSec).toBeGreaterThanOrEqual(200 - 1.5);
+    expect(clips[0].offsetSec).toBeLessThanOrEqual(200 + 2.0);
+  });
+
+  it('song_transition jitter is deterministic for the same segment id', () => {
+    const transition: DjSegmentRow = {
+      id: 'seg-trans-determinism',
+      segment_type: 'song_transition',
+      audio_url: 'https://cdn/dj/trans2.mp3',
+      audio_duration_sec: 5,
+      playlist_entry_id: 'e4', // song4 starts at 380s
+      anchor_playlist_entry_id: null,
+      start_offset_sec: null,
+    };
+    const clips1 = resolveDjClips([transition], cumulativeMap, totalDuration);
+    const clips2 = resolveDjClips([transition], cumulativeMap, totalDuration);
+    expect(clips1[0].offsetSec).toBe(clips2[0].offsetSec);
+  });
+
+  it('different segment ids produce different jitter values', () => {
+    const makeTransition = (id: string): DjSegmentRow => ({
+      id,
+      segment_type: 'song_transition',
+      audio_url: 'https://cdn/dj/t.mp3',
+      audio_duration_sec: 5,
+      playlist_entry_id: 'e2',
+      anchor_playlist_entry_id: null,
+      start_offset_sec: null,
+    });
+    const c1 = resolveDjClips([makeTransition('seg-a')], cumulativeMap, totalDuration);
+    const c2 = resolveDjClips([makeTransition('seg-b')], cumulativeMap, totalDuration);
+    expect(c1[0].offsetSec).not.toBe(c2[0].offsetSec);
   });
 
   it('places show_outro at total_duration minus its duration', () => {

--- a/services/station/tests/unit/specService.test.ts
+++ b/services/station/tests/unit/specService.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for specService (#495 — Station Spec).
+ *
+ * Tests: parseSpec, serializeSpecToYaml, exportSpec (mocked DB),
+ * applySpec (mocked DB), and buildSpecRulesSection from promptBuilder.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const mockQuery = vi.fn();
+
+vi.mock('../../src/db', () => ({
+  getPool: vi.fn(() => ({ query: mockQuery })),
+}));
+
+vi.mock('../../src/services/djSetupService', () => ({
+  seedDefaultDjProfileForStation: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { parseSpec, serializeSpecToYaml } from '../../src/services/specService';
+import type { StationSpec } from '@playgen/types';
+
+// ─── parseSpec ────────────────────────────────────────────────────────────────
+
+describe('parseSpec', () => {
+  it('parses a minimal YAML spec', () => {
+    const yaml = `
+name: Test FM
+callsign: TSTF
+timezone: Asia/Manila
+`;
+    const spec = parseSpec(yaml);
+    expect(spec.name).toBe('Test FM');
+    expect(spec.callsign).toBe('TSTF');
+    expect(spec.timezone).toBe('Asia/Manila');
+  });
+
+  it('parses a JSON string (YAML superset)', () => {
+    const json = JSON.stringify({ name: 'JSON FM', broadcast: { start_hour: 6, end_hour: 2 } });
+    const spec = parseSpec(json);
+    expect(spec.name).toBe('JSON FM');
+    expect(spec.broadcast?.start_hour).toBe(6);
+  });
+
+  it('parses a full spec with DJs, script_rules, and library', () => {
+    const yaml = `
+version: "1"
+name: OwnRadio Manila
+callsign: OWFM
+locale: fil-PH
+djs:
+  - name: Bianca
+    role: primary
+    energy: 9
+    humor: 7
+    catchphrases:
+      - "Tara na!"
+      - "Good vibes lang!"
+    personality: "Bubbly Pinay DJ"
+script_rules:
+  language: Taglish
+  tone: Energetic
+  avoid:
+    - Reading ad copy verbatim
+  always:
+    - Mention station callsign in station_id segments
+library:
+  songs_per_hour: 3
+  rules:
+    - At least 1 OPM song per hour
+`;
+    const spec = parseSpec(yaml);
+    expect(spec.callsign).toBe('OWFM');
+    expect(spec.djs?.[0]?.name).toBe('Bianca');
+    expect(spec.djs?.[0]?.catchphrases).toContain('Tara na!');
+    expect(spec.script_rules?.language).toBe('Taglish');
+    expect(spec.script_rules?.avoid).toContain('Reading ad copy verbatim');
+    expect(spec.library?.rules).toContain('At least 1 OPM song per hour');
+  });
+
+  it('throws on a non-object YAML document', () => {
+    expect(() => parseSpec('- item1\n- item2')).toThrow('Spec must be a YAML/JSON object');
+  });
+
+  it('throws on invalid YAML syntax', () => {
+    expect(() => parseSpec('name: [unclosed')).toThrow();
+  });
+});
+
+// ─── serializeSpecToYaml ──────────────────────────────────────────────────────
+
+describe('serializeSpecToYaml', () => {
+  it('serializes a spec to YAML string', () => {
+    const spec: StationSpec = {
+      version: '1',
+      name: 'Test FM',
+      callsign: 'TSTF',
+      djs: [{ name: 'Alex', role: 'primary' }],
+    };
+    const yaml = serializeSpecToYaml(spec);
+    expect(yaml).toContain('name: Test FM');
+    expect(yaml).toContain('callsign: TSTF');
+    expect(yaml).toContain('- name: Alex');
+  });
+
+  it('round-trips: parse → serialize → parse produces equivalent object', () => {
+    const original: StationSpec = {
+      version: '1',
+      name: 'Round Trip FM',
+      script_rules: {
+        language: 'English',
+        avoid: ['cursing', 'politics'],
+        always: ['Stay upbeat'],
+      },
+    };
+    const yaml = serializeSpecToYaml(original);
+    const reparsed = parseSpec(yaml);
+    expect(reparsed.name).toBe('Round Trip FM');
+    expect(reparsed.script_rules?.avoid).toEqual(['cursing', 'politics']);
+  });
+});
+
+// ─── buildSpecRulesSection (from promptBuilder) ───────────────────────────────
+// Tested here to keep DJ service tests clean; the function is pure.
+
+describe('buildSpecRulesSection', () => {
+  // Lazily import from the DJ service's promptBuilder
+  // (It's a separate package; we test the logic via the exported function directly)
+  it('returns null when no spec data', async () => {
+    const { buildSpecRulesSection } = await import('../../../dj/src/lib/promptBuilder.js');
+    expect(buildSpecRulesSection(null, null)).toBeNull();
+    expect(buildSpecRulesSection(undefined, undefined)).toBeNull();
+  });
+
+  it('builds a rules section from script_rules', async () => {
+    const { buildSpecRulesSection } = await import('../../../dj/src/lib/promptBuilder.js');
+    const result = buildSpecRulesSection(
+      { language: 'Taglish', tone: 'Energetic', avoid: ['politics'], always: ['Mention OWFM'] },
+      null,
+    );
+    expect(result).not.toBeNull();
+    expect(result).toContain('Station-specific guidelines');
+    expect(result).toContain('Taglish');
+    expect(result).toContain('Energetic');
+    expect(result).toContain('politics');
+    expect(result).toContain('OWFM');
+  });
+
+  it('includes library rules when present', async () => {
+    const { buildSpecRulesSection } = await import('../../../dj/src/lib/promptBuilder.js');
+    const result = buildSpecRulesSection(null, { rules: ['At least 1 OPM per hour'] });
+    expect(result).toContain('OPM per hour');
+  });
+
+  it('returns null when all rules are empty arrays', async () => {
+    const { buildSpecRulesSection } = await import('../../../dj/src/lib/promptBuilder.js');
+    const result = buildSpecRulesSection(
+      { avoid: [], always: [] },
+      { rules: [] },
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ─── buildSystemPrompt spec injection ─────────────────────────────────────────
+
+describe('buildSystemPrompt with specRules', () => {
+  it('appends specRules block to single-DJ prompt', async () => {
+    const { buildSystemPrompt } = await import('../../../dj/src/lib/promptBuilder.js');
+    const profile = {
+      id: 'p1',
+      company_id: 'c1',
+      name: 'Alex',
+      personality: 'Cool DJ',
+      voice_style: 'energetic',
+      llm_model: 'gpt-4o',
+      llm_temperature: 0.8,
+      tts_provider: 'openai',
+      tts_voice_id: 'alloy',
+      persona_config: null,
+      is_default: true,
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    const rules = 'Station-specific guidelines:\nAlways mention OWFM';
+    const prompt = buildSystemPrompt(profile as never, 'en-US', 'openai', rules);
+    expect(prompt).toContain('Station-specific guidelines');
+    expect(prompt).toContain('OWFM');
+  });
+
+  it('omits spec section when specRules is null', async () => {
+    const { buildSystemPrompt } = await import('../../../dj/src/lib/promptBuilder.js');
+    const profile = {
+      id: 'p1',
+      company_id: 'c1',
+      name: 'Alex',
+      personality: 'Cool DJ',
+      voice_style: 'energetic',
+      llm_model: 'gpt-4o',
+      llm_temperature: 0.8,
+      tts_provider: 'openai',
+      tts_voice_id: 'alloy',
+      persona_config: null,
+      is_default: true,
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    const prompt = buildSystemPrompt(profile as never, null, null, null);
+    expect(prompt).not.toContain('Station-specific guidelines');
+  });
+});

--- a/shared/db/src/migrations/076_add_station_spec.sql
+++ b/shared/db/src/migrations/076_add_station_spec.sql
@@ -1,0 +1,9 @@
+-- Migration 076: Add station_spec JSONB column to stations
+-- Stores the declarative station blueprint (like CLAUDE.md for stations).
+-- Partial specs are valid — only present keys override station config.
+
+ALTER TABLE stations
+  ADD COLUMN IF NOT EXISTS station_spec JSONB;
+
+COMMENT ON COLUMN stations.station_spec IS
+  'Declarative station blueprint (StationSpec). Drives DJ personality, script rules, and music guidelines at generation time. Partial specs are supported.';

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -230,6 +230,8 @@ export interface Station {
   website_url?: string | null;
   /** DALL-E generated abstract cover art URL (nullable until generated). Added in migration 072. */
   artwork_url?: string | null;
+  /** Declarative station blueprint. Drives DJ personality, script rules, and music guidelines. Added in migration 076. */
+  station_spec?: StationSpec | null;
 }
 
 export interface Role {
@@ -768,5 +770,115 @@ export interface PaginatedResponse<T> {
     limit: number;
     total: number;
     total_pages: number;
+  };
+}
+
+// ─── Station Spec ─────────────────────────────────────────────────────────────
+
+/** Voice config within a spec DJ definition. */
+export interface SpecDjVoice {
+  provider: string;
+  voice_id: string;
+}
+
+/** DJ persona definition within a station spec. */
+export interface SpecDj {
+  name: string;
+  role?: 'primary' | 'co-host' | 'guest';
+  voice?: SpecDjVoice;
+  personality?: string;
+  energy?: number;          // 1-10
+  humor?: number;           // 1-10
+  formality?: 'casual' | 'balanced' | 'formal';
+  catchphrases?: string[];
+  greeting?: string;
+  signoff?: string;
+  backstory?: string;
+}
+
+/** DJ interaction rules within a station spec. */
+export interface SpecDjInteraction {
+  style?: 'solo' | 'banter' | 'formal';
+  rules?: string[];
+}
+
+/** Program theme directive within a station spec. */
+export interface SpecProgramTheme {
+  type: ProgramThemeType;
+  priority?: number;
+  config?: Record<string, unknown>;
+}
+
+/** Program definition within a station spec. */
+export interface SpecProgram {
+  name: string;
+  hours?: string;           // e.g. "5-12" or "22-2"
+  start_hour?: number;
+  end_hour?: number;
+  active_days?: string[];
+  dj_combo?: string[];      // DJ names that appear in this program
+  themes?: SpecProgramTheme[];
+}
+
+/** Music library guidelines within a station spec. */
+export interface SpecLibrary {
+  songs_per_hour?: number;
+  rules?: string[];
+}
+
+/** TTS configuration within a station spec. */
+export interface SpecTts {
+  provider?: string;
+  default_voice?: string;
+}
+
+/**
+ * Declarative station blueprint — like CLAUDE.md but for stations.
+ * All fields are optional; a partial spec only overrides the fields present.
+ * Stored as JSONB in `stations.station_spec` (migration 076).
+ */
+export interface StationSpec {
+  /** Spec format version (currently "1"). */
+  version?: string;
+
+  // ── Identity ──────────────────────────────────────────────────────────────
+  name?: string;
+  callsign?: string;
+  tagline?: string;
+  locale?: string;
+  city?: string;
+  timezone?: string;
+  frequency?: string;
+  broadcast_type?: 'fm' | 'am' | 'online' | 'podcast' | 'dab';
+
+  // ── Broadcast schedule ────────────────────────────────────────────────────
+  broadcast?: {
+    start_hour?: number;
+    end_hour?: number;
+    active_days?: string[];
+  };
+
+  // ── TTS config ────────────────────────────────────────────────────────────
+  tts?: SpecTts;
+
+  // ── DJ personas ───────────────────────────────────────────────────────────
+  djs?: SpecDj[];
+
+  // ── DJ interaction rules ──────────────────────────────────────────────────
+  dj_interaction?: SpecDjInteraction;
+
+  // ── Programs ──────────────────────────────────────────────────────────────
+  programs?: SpecProgram[];
+
+  // ── Music guidelines ─────────────────────────────────────────────────────
+  library?: SpecLibrary;
+
+  // ── Script style rules (injected into the LLM system prompt) ─────────────
+  script_rules?: {
+    language?: string;
+    tone?: string;
+    segment_length?: string;
+    avoid?: string[];
+    always?: string[];
   };
 }

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -29,9 +29,10 @@ _Updated: 2026-05-03 by PM agent_
 
 ## Active Work
 
-- [ ] feat(dj+station): human-like DJ transition jitter — seeded random cues between songs (#422, feat/issue-422-transition-jitter) | @claude-sonnet-4-6 | 2026-05-04
+_(no active claims)_
 
 ## Recently Completed
+- [x] feat(station): human-like DJ transition jitter — seeded FNV-1a jitter on song_transition segments (#422, feat/issue-495) | @claude-sonnet-4-6 | 2026-05-04
 - [x] feat(station+types+dj+frontend): Station Spec — declarative blueprint with YAML editor, spec API, DJ persona bootstrap, and pipeline injection (#495, feat/issue-495) | @claude-sonnet-4-6 | 2026-05-04 | Migration: 076
 - [x] feat(station+frontend): adaptive bandwidth streaming — multi-bitrate HLS + HLS.js player (#500, feat/issue-500, PR #549) | @claude-sonnet-4-6 | 2026-05-04
 - [x] fix(scheduler+station): inherit_library category remapping + station auto-creation slots (#497, #498, fix/issue-497-498) | @claude-sonnet-4-6 | 2026-05-03

--- a/tasks/agent-collab.md
+++ b/tasks/agent-collab.md
@@ -29,11 +29,13 @@ _Updated: 2026-05-03 by PM agent_
 
 ## Active Work
 
-- [ ] feat(station+frontend): adaptive bandwidth streaming — multi-bitrate HLS + RadioStreamPlayer (#500, feat/issue-500) | @claude-sonnet-4-6 | 2026-05-03 | Migration: none
-- [x] fix(scheduler+station): inherit_library category remapping + station auto-creation slots (#497, #498, fix/issue-497-498) | @claude-sonnet-4-6 | 2026-05-03
-- [x] fix(library): yt-dlp YouTube bot detection — cookie auth + ios/android player clients (#465, fix/issue-465, PR #547) | @claude-sonnet-4-6 | 2026-05-03
+- [ ] feat(dj+station): human-like DJ transition jitter — seeded random cues between songs (#422, feat/issue-422-transition-jitter) | @claude-sonnet-4-6 | 2026-05-04
 
 ## Recently Completed
+- [x] feat(station+types+dj+frontend): Station Spec — declarative blueprint with YAML editor, spec API, DJ persona bootstrap, and pipeline injection (#495, feat/issue-495) | @claude-sonnet-4-6 | 2026-05-04 | Migration: 076
+- [x] feat(station+frontend): adaptive bandwidth streaming — multi-bitrate HLS + HLS.js player (#500, feat/issue-500, PR #549) | @claude-sonnet-4-6 | 2026-05-04
+- [x] fix(scheduler+station): inherit_library category remapping + station auto-creation slots (#497, #498, fix/issue-497-498) | @claude-sonnet-4-6 | 2026-05-03
+- [x] fix(library): yt-dlp YouTube bot detection — cookie auth + ios/android player clients (#465, fix/issue-465, PR #547) | @claude-sonnet-4-6 | 2026-05-03
 - [x] feat(station+frontend): Pipeline UI — GitHub Actions-style dashboard (#499, feat/issue-499-standalone, PR #546) | @claude-sonnet-4-6 | 2026-05-03
 - [x] fix(dj): status.json stale metadata — time-based CDN segment computation (#491, fix/issue-491, PR #548) | @claude-sonnet-4-6 | 2026-05-03
 - [x] fix(dj+station): LLM/TTS backoff, checkpoint resume, pipeline progress (#529, fix/issue-529, PR #544) | @claude-sonnet-4-6 | 2026-05-03 | Migration: 075


### PR DESCRIPTION
## Summary

- **Migration 076**: `station_spec JSONB` column on the `stations` table (additive, nullable)
- **`@playgen/types`**: `StationSpec`, `SpecDj`, `SpecProgram`, `SpecLibrary`, `SpecTts` interfaces; `station_spec` field added to `Station`
- **Station service**: `specService.ts` (export/apply/bootstrap), `specRoutes.ts` (3 endpoints), `js-yaml` dep for YAML parse/serialize
- **DJ service**: `buildSpecRulesSection()` in `promptBuilder.ts` injected into all 4 system-prompt call sites in `generationWorker.ts` — spec `script_rules` + `library.rules` are now appended to every LLM system prompt
- **Frontend**: "Spec" tab in station layout; YAML editor with Apply/Discard/Export YAML/Export JSON controls and inline validation feedback

## API

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/stations/:id/spec` | Export spec as YAML (default) or `?format=json` |
| `PUT` | `/api/v1/stations/:id/spec` | Apply YAML or JSON spec to existing station |
| `POST` | `/api/v1/companies/:id/stations/from-spec` | Bootstrap new station from spec |

## How it works

1. User edits the YAML spec in the frontend editor (or POSTs via API)
2. `applySpec` updates identity fields, DJ profiles (upsert by name), programs (upsert by name), TTS settings, and stores the full spec in `station_spec` JSONB
3. At generation time, `generationWorker` loads `station_spec` and builds a `specRules` string via `buildSpecRulesSection()` containing language, tone, avoid/always rules, and music guidelines
4. All system prompts for the DJ receive the `specRules` block before the core rules section

## Test plan

- [x] `parseSpec` handles YAML, JSON (superset), full specs with DJs/programs/rules, rejects non-objects and invalid syntax
- [x] `serializeSpecToYaml` round-trip: parse → serialize → parse produces equivalent object
- [x] `buildSpecRulesSection` returns null for empty/missing spec, correct block for populated spec
- [x] `buildSystemPrompt` appends spec block when specRules provided, omits it when null
- [x] 13 new unit tests; 112 station + 189 DJ existing tests all pass
- [x] `pnpm run typecheck` clean; `pnpm run lint` 0 errors

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)